### PR TITLE
Guard sync routine to enable safe imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -308,5 +308,6 @@ def sync_videos():
 
     print("Synchronisation terminée. Les vidéos, les titres en gras, sans troncature et avec wrapping sont ajoutés.")
 
-# Exécution unique de la synchronisation
-sync_videos()
+if __name__ == "__main__":
+    # Exécution unique de la synchronisation
+    sync_videos()

--- a/tests/test_parse_duration.py
+++ b/tests/test_parse_duration.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+# Ajoute le répertoire parent au chemin pour pouvoir importer main
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+def test_parse_duration_basic_cases():
+    assert main.parse_duration("PT2H34M") == "02:34:00"
+    assert main.parse_duration("PT2H34S") == "02:00:34"
+    assert main.parse_duration("PT15M33S") == "00:15:33"
+    assert main.parse_duration("PT0S") == "00:00:00"
+    assert main.parse_duration("INVALID") == "Inconnue"


### PR DESCRIPTION
## Summary
- Avoid running the synchronization routine on module import
- Add tests covering parse_duration for basic ISO 8601 durations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68954185d2448320aba504d6cbf6d8d2