### PR TITLE
Clarify parse_duration docstring

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,10 +7,7 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 def parse_duration(iso_duration):
-    """
-    Transforme une durée au format ISO (ex: "PT2H34M" ou "PT2H34S") en une chaîne "HH:MM:SS".
-    On garde séparément les heures, minutes et secondes.
-    """
+    """Convertit une durée ISO 8601 en chaîne formatée "HH:MM:SS"."""
     pattern = re.compile(r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?')
     match = pattern.match(iso_duration)
     if not match:


### PR DESCRIPTION
## Summary
- Document parse_duration as converting ISO durations to HH:MM:SS format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68954350b9c4832089ee30e2c5668fc6