### PR TITLE
chore: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-        # Utilisation de la version 3 pour checkout
+      - uses: actions/checkout@v4
+        # Utilisation de la version 4 pour checkout
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
- use checkout v4 in sync workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689545b9478083208bb4ddb5aed90e0b