### PR TITLE
Use requirements file in workflow and pin dependencies

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,7 +18,7 @@ jobs:
         # Mise à jour de setup-python à la version 4
 
       - name: Install dependencies
-        run: pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib requests
+        run: pip install -r requirements.txt
 
       - name: Run script
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-requests
-google-api-python-client
-google-auth
-google-auth-httplib2
+google-api-python-client==2.178.0
+google-auth==2.40.3
+google-auth-httplib2==0.2.0
+google-auth-oauthlib==1.2.0
+requests==2.32.4


### PR DESCRIPTION
## Summary
- Install dependencies from `requirements.txt` in sync workflow
- Pin Python library versions in `requirements.txt` for reproducible installs

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689545ba8aec8320a602a42769d1ff2b