### PR TITLE
Remove unused artifact upload step from sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,9 +29,3 @@ jobs:
           echo "$SERVICE_ACCOUNT_JSON" > service_account.json
           python main.py
 
-      # Étape optionnelle : Upload d'artefact en utilisant la version mise à jour de l'action
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: my-artifact
-          path: path/to/artifact


### PR DESCRIPTION
## Summary
- remove placeholder artifact upload step from GitHub Actions sync workflow

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689545bb6fb48320b79773639ebdcbdd