### PR TITLE
Clarify parse_duration regex

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from googleapiclient.discovery import build
 
 def parse_duration(iso_duration):
     """Convertit une durée ISO 8601 en chaîne formatée "HH:MM:SS"."""
+    # Regex pour extraire heures, minutes et secondes
     pattern = re.compile(r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?')
     match = pattern.match(iso_duration)
     if not match:


### PR DESCRIPTION
## Summary
- add comments explaining parse_duration regex

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895468ab0948320ac91bae90e51758d