### PR TITLE
feat: replace Vite icon with YouTube logo

### DIFF
--- a/bolt-app/index.html
+++ b/bolt-app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/youtube-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Youtube like</title>
   </head>

--- a/bolt-app/public/youtube-logo.svg
+++ b/bolt-app/public/youtube-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect width="24" height="24" rx="4" fill="#FF0000"/>
+  <polygon points="10,8 16,12 10,16" fill="#FFFFFF"/>
+</svg>

--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Youtube, RefreshCw } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { VideoGrid } from './components/VideoGrid';
 import { DurationTabs } from './components/DurationTabs';
 import { SearchBar } from './components/SearchBar';
@@ -92,7 +92,7 @@ export default function App() {
                 className="flex items-center gap-3 group"
                 disabled={isLoading}
               >
-                <Youtube className="h-8 w-8 text-youtube-red" />
+                <img src="/youtube-logo.svg" alt="YouTube logo" className="h-8 w-8" />
                 <h1 className="text-xl font-semibold text-youtube-black dark:text-white flex items-center gap-2">
                   Mes Vidéos YouTube
                   <RefreshCw 


### PR DESCRIPTION
## Summary
- add YouTube logo asset and link to it in index.html
- swap lucide-react icon for inline logo image in `App.tsx`

## Testing
- `npm run build`
- `pytest`
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system.)*

------
https://chatgpt.com/codex/tasks/task_e_68adaeb78a388320adfd138018b23291