### PR TITLE
Fix: correct SortOptions import and logo import

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -14,5 +14,7 @@ import { sortVideos } from './utils/sortUtils';
 import { useVideos } from './hooks/useVideos';
 import { useSound } from './hooks/useSound';
 import { SearchFilters } from './types/search';
-import { SortOptions } from './types/sor
- import logoUrl from './assets/logo.png';
+import { SortOptions } from './types/sort';
+
+// si tu veux utiliser le logo depuis le code React:
+import logoUrl from './assets/logo.png';


### PR DESCRIPTION
## Summary
- fix broken SortOptions import and remove stray truncated line
- document React logo import for future use

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68adc0e3f6cc8320a92f060194c6068e