### PR TITLE
Use BASE_URL for YouTube logo path

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -92,7 +92,11 @@ export default function App() {
                 className="flex items-center gap-3 group"
                 disabled={isLoading}
               >
-                <img src="/youtube-logo.svg" alt="YouTube logo" className="h-8 w-8" />
+                <img
+                  src={`${import.meta.env.BASE_URL}youtube-logo.svg`}
+                  alt="YouTube logo"
+                  className="h-8 w-8"
+                />
                 <h1 className="text-xl font-semibold text-youtube-black dark:text-white flex items-center gap-2">
                   Mes Vidéos YouTube
                   <RefreshCw


### PR DESCRIPTION
## Summary
- include `BASE_URL` when referencing the YouTube logo image

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm install --no-save globals` *(fails: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adcf0a274c8320a37fce3af2e8731e