### PR TITLE
refactor: update favicon paths

### DIFF
--- a/bolt-app/index.html
+++ b/bolt-app/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
- <link rel="icon" type="image/png" href="/youtube-to-sheets/favicon.png" />
- <link rel="apple-touch-icon" href="/youtube-to-sheets/favicon.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" />
+    <link rel="apple-touch-icon" href="%BASE_URL%favicon.png" />
       
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Youtube like</title>


### PR DESCRIPTION
## Summary
- use %BASE_URL% placeholder for favicon references

## Testing
- `pytest`
- `npm run build`
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68adcf0e272c832093d3a8b99bbc333a