### PR TITLE
Fix favicon path in index.html

### DIFF
--- a/bolt-app/index.html
+++ b/bolt-app/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" />
-    <link rel="apple-touch-icon" href="%BASE_URL%favicon.png" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
       
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>Youtube like</title>


### PR DESCRIPTION
## Summary
- fix favicon path so custom icon loads instead of default

## Testing
- `npm --prefix bolt-app run lint` *(fails: Cannot find package 'globals')*
- `npm --prefix bolt-app install globals --no-save` *(fails: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68addc5c470483208e28d8b2de370feb