### PR TITLE
Inclure l’heure dans la date des vidéos

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,6 +84,11 @@ def get_thumbnail_url(video_data):
             return thumb_info[quality]['url']
     return ""
 
+
+def format_published_at(iso_timestamp):
+    dt = datetime.strptime(iso_timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    return f"'{dt.strftime('%d/%m/%Y %H:%M')}"
+
 def sync_videos():
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     SPREADSHEET_ID = os.environ.get("SPREADSHEET_ID")
@@ -142,9 +147,10 @@ def sync_videos():
             tags_str = ", ".join(tags)
 
             original_published_at = snippet['publishedAt']
-            dt = datetime.strptime(original_published_at, "%Y-%m-%dT%H:%M:%SZ")
-            # On préfixe la date d'une apostrophe pour l'afficher au format "07/01/2025"
-            published_at_formatted = f"'{dt.strftime('%d/%m/%Y')}"
+            # On préfixe la date d'une apostrophe pour l'afficher au format
+            # "07/01/2025 12:34" et éviter la conversion automatique de Google
+            # Sheets
+            published_at_formatted = format_published_at(original_published_at)
             
             # Affichage uniquement de l'URL brute de la miniature
             thumbnail_formula = thumbnail_url if thumbnail_url else ""

--- a/tests/test_published_at.py
+++ b/tests/test_published_at.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from main import format_published_at
+
+
+def test_format_published_at_includes_time_and_prefix():
+    iso = "2025-01-07T13:45:00Z"
+    assert format_published_at(iso) == "'07/01/2025 13:45"


### PR DESCRIPTION
## Summary
- Ajout de `format_published_at` pour inclure l’heure et éviter la conversion automatique de Google Sheets
- Adaptation de `sync_videos` pour utiliser ce format
- Ajout d’un test vérifiant la présence de l’heure et de l’apostrophe

## Testing
- `flake8 main.py tests/test_published_at.py tests/test_duration.py tests/test_parse_duration.py` *(command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade70fc5a483209ca95db36365727d