### PR TITLE
feat: parse and format publish time

### DIFF
--- a/bolt-app/package.json
+++ b/bolt-app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test --experimental-transform-types"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/bolt-app/src/utils/timeUtils.test.ts
+++ b/bolt-app/src/utils/timeUtils.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDate, formatPublishDate } from './timeUtils.ts';
+
+test('parseDate parses DD/MM/YYYY HH:MM format', () => {
+  const result = parseDate('17/05/2024 14:30');
+  assert.ok(result);
+  assert.equal(result?.getFullYear(), 2024);
+  assert.equal(result?.getMonth(), 4);
+  assert.equal(result?.getDate(), 17);
+  assert.equal(result?.getHours(), 14);
+  assert.equal(result?.getMinutes(), 30);
+});
+
+test('formatPublishDate formats recent dates with time', () => {
+  const now = new Date();
+  const recent = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+  const dd = String(recent.getDate()).padStart(2, '0');
+  const mm = String(recent.getMonth() + 1).padStart(2, '0');
+  const yyyy = recent.getFullYear();
+  const hh = String(recent.getHours()).padStart(2, '0');
+  const min = String(recent.getMinutes()).padStart(2, '0');
+  const dateString = `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+  const expected = new Intl.DateTimeFormat('fr-FR', { hour: '2-digit', minute: '2-digit' }).format(recent);
+  assert.equal(formatPublishDate(dateString), expected);
+});
+
+test('formatPublishDate formats older dates with full date', () => {
+  const now = new Date();
+  const older = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+  const dd = String(older.getDate()).padStart(2, '0');
+  const mm = String(older.getMonth() + 1).padStart(2, '0');
+  const yyyy = older.getFullYear();
+  const hh = String(older.getHours()).padStart(2, '0');
+  const min = String(older.getMinutes()).padStart(2, '0');
+  const dateString = `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+  const expected = new Intl.DateTimeFormat('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' }).format(older);
+  assert.equal(formatPublishDate(dateString), expected);
+});


### PR DESCRIPTION
## Summary
- handle dates with time in `parseDate`
- show formatted hours for recent videos while keeping full date for older ones
- cover publish date formatting with new tests

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ade72746d48320bbb2abc4cc18475d