### PR TITLE
chore: add globals dev dependency

### DIFF
--- a/bolt-app/package.json
+++ b/bolt-app/package.json
@@ -25,6 +25,7 @@
     "eslint": "^9.9.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
+    "globals": "^13.20.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",


### PR DESCRIPTION
## Summary
- add `globals` to devDependencies for bolt-app's ESLint configuration

## Testing
- `npm install` *(fails: 403 Forbidden fetching globals)*
- `npm run lint` *(fails: missing package 'globals')*
- `npm test` *(fails: 5 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0ae77430832089f6e0dd1f704208