### PR TITLE
Support more date formats in parseDate

### DIFF
--- a/bolt-app/src/utils/timeUtils.ts
+++ b/bolt-app/src/utils/timeUtils.ts
@@ -25,14 +25,14 @@ export function parseDate(dateString: string): Date | null {
     const ddmmyyyyTime = formats[1].exec(dateString);
     if (ddmmyyyyTime) {
       const [, day, month, year, hour, minute] = ddmmyyyyTime;
-      return new Date(
-      );
+      return new Date(Number(year), Number(month) - 1, Number(day), Number(hour), Number(minute));
     }
 
     // Test format DD/MM/YYYY
     const ddmmyyyy = formats[2].exec(dateString);
     if (ddmmyyyy) {
       const [, day, month, year] = ddmmyyyy;
+      return new Date(Number(year), Number(month) - 1, Number(day));
     }
     
     // Test format français
@@ -45,6 +45,7 @@ export function parseDate(dateString: string): Date | null {
         'septembre': '09', 'octobre': '10', 'novembre': '11', 'décembre': '12'
       };
       const monthNumber = Number(monthMap[month.toLowerCase()]);
+      return new Date(Number(year), monthNumber - 1, Number(day));
     }
 
     // Si aucun format ne correspond, essaie le parsing natif


### PR DESCRIPTION
## Summary
- parse DD/MM/YYYY HH:MM strings into Date objects
- handle DD/MM/YYYY dates
- add support for French month names

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0cfc81548320a3de8016a7081772