### PR TITLE
Revert export-sheets.yml to original workflow

### DIFF
--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -1,47 +1,29 @@
 name: Export Google Sheet to public data
-
 on:
-  push:
-    branches: ['main']
   workflow_dispatch:
-    schedule:
-       - cron: "5 4 * * *"  # everyday at 04:05 UTC
   schedule:
+    - cron: "5 4 * * *" # everyday at 04:05 UTC
 permissions:
   contents: write
-
 jobs:
   export:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
       - name: Install deps
         run: pip install -r requirements.txt
-
       - name: Export sheet to CSV/JSON
         env:
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
-              SHEET_TABS: |
-          0-5 min
-          5-10 min
-          10-20 min
-          20-30 min
-          30-40 min
-          40-50 min
-          50-60 min
-          60 + min
-          Inconnu
+          SHEET_RANGE: AllVideos!A1:Z # adapt the sheet name and range if needed
         run: python scripts/export_sheet.py
-
       - name: Commit updated data
         run: |
-          git config user.name  "github-actions[bot]"
+          git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add bolt-app/public/data/videos.csv bolt-app/public/data/videos.json || true
           if git diff --cached --quiet; then


### PR DESCRIPTION
This change restores the earlier version of the GitHub Actions workflow file export-sheets.yml that uses SHEET_RANGE and a single tab instead of the multi-tab configuration introduced in commits 09752bf and 40ca24c.