### PR TITLE
feat: add unknown duration tab

### DIFF
--- a/bolt-app/src/types/sheets.ts
+++ b/bolt-app/src/types/sheets.ts
@@ -2,7 +2,7 @@ export interface SheetTab {
   name: string;
   range: string;
   durationRange: {
-    min: number;
+    min: number | null;
     max: number | null;
   };
 }

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const SHEET_TABS: SheetTab[] = [
   { name: '40-50min', range: '40-50min!A2:N1000', durationRange: { min: 40, max: 50 } },
   { name: '50-60min', range: '50-60min!A2:N1000', durationRange: { min: 50, max: 60 } },
   { name: '60Plusmin', range: '60Plusmin!A2:N1000', durationRange: { min: 60, max: null } },
+  { name: 'Inconnue', range: 'Inconnue!A2:N1000', durationRange: { min: null, max: null } },
 ];
 
 export const SPREADSHEET_ID = '1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU';

--- a/bolt-app/src/utils/durationUtils.ts
+++ b/bolt-app/src/utils/durationUtils.ts
@@ -30,7 +30,10 @@ export function formatDuration(duration: string): string {
   return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 }
 
-export function formatDurationRange(min: number, max: number | null): string {
+export function formatDurationRange(min: number | null, max: number | null): string {
+  if (min === null && max === null) {
+    return 'Inconnue';
+  }
   if (max === null) {
     return `${min}+ min`;
   }

--- a/bolt-app/src/utils/videoFilters.ts
+++ b/bolt-app/src/utils/videoFilters.ts
@@ -4,13 +4,16 @@ import { getDurationInMinutes } from './durationUtils';
 
 export function filterVideosByDuration(videos: VideoData[], tab: SheetTab | null): VideoData[] {
   if (!tab) return videos;
-  
+
   return videos.filter(video => {
-    const duration = getDurationInMinutes(video.duration);
     const { min, max } = tab.durationRange;
-    return max === null 
-      ? duration >= min 
-      : duration >= min && duration < max;
+    if (min === null && max === null) {
+      return video.duration === 'Inconnue';
+    }
+    const duration = getDurationInMinutes(video.duration);
+    return max === null
+      ? duration >= (min as number)
+      : duration >= (min as number) && duration < max;
   });
 }
 


### PR DESCRIPTION
## Summary
- add `Inconnue` sheet tab with null duration range
- handle unknown durations in utilities

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68ae378e2a848320b86197b9d9e56374