### PR TITLE
Expand Google Sheets range

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -1,15 +1,15 @@
 import { SheetTab } from '../types/sheets';
 
 export const SHEET_TABS: SheetTab[] = [
-  { name: '0-5min', range: '0-5min!A2:N', durationRange: { min: 0, max: 5 } },
-  { name: '5-10min', range: '5-10min!A2:N', durationRange: { min: 5, max: 10 } },
-  { name: '10-20min', range: '10-20min!A2:N', durationRange: { min: 10, max: 20 } },
-  { name: '20-30min', range: '20-30min!A2:N', durationRange: { min: 20, max: 30 } },
-  { name: '30-40min', range: '30-40min!A2:N', durationRange: { min: 30, max: 40 } },
-  { name: '40-50min', range: '40-50min!A2:N', durationRange: { min: 40, max: 50 } },
-  { name: '50-60min', range: '50-60min!A2:N', durationRange: { min: 50, max: 60 } },
-  { name: '60Plusmin', range: '60Plusmin!A2:N', durationRange: { min: 60, max: null } },
-  { name: 'Inconnue', range: 'Inconnue!A2:N', durationRange: { min: null, max: null } },
+  { name: '0-5min', range: '0-5min!A2:N1000', durationRange: { min: 0, max: 5 } },
+  { name: '5-10min', range: '5-10min!A2:N1000', durationRange: { min: 5, max: 10 } },
+  { name: '10-20min', range: '10-20min!A2:N1000', durationRange: { min: 10, max: 20 } },
+  { name: '20-30min', range: '20-30min!A2:N1000', durationRange: { min: 20, max: 30 } },
+  { name: '30-40min', range: '30-40min!A2:N1000', durationRange: { min: 30, max: 40 } },
+  { name: '40-50min', range: '40-50min!A2:N1000', durationRange: { min: 40, max: 50 } },
+  { name: '50-60min', range: '50-60min!A2:N1000', durationRange: { min: 50, max: 60 } },
+  { name: '60Plusmin', range: '60Plusmin!A2:N1000', durationRange: { min: 60, max: null } },
+  { name: 'Inconnue', range: 'Inconnue!A2:N1000', durationRange: { min: null, max: null } },
 ];
 
 export const SPREADSHEET_ID = '1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU';

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -1,14 +1,14 @@
 import { SheetTab } from '../types/sheets';
 
 export const SHEET_TABS: SheetTab[] = [
-  { name: '0-5min', range: '0-5min!A2:N1000', durationRange: { min: 0, max: 5 } },
-  { name: '5-10min', range: '5-10min!A2:N1000', durationRange: { min: 5, max: 10 } },
-  { name: '10-20min', range: '10-20min!A2:N1000', durationRange: { min: 10, max: 20 } },
-  { name: '20-30min', range: '20-30min!A2:N1000', durationRange: { min: 20, max: 30 } },
-  { name: '30-40min', range: '30-40min!A2:N1000', durationRange: { min: 30, max: 40 } },
-  { name: '40-50min', range: '40-50min!A2:N1000', durationRange: { min: 40, max: 50 } },
-  { name: '50-60min', range: '50-60min!A2:N1000', durationRange: { min: 50, max: 60 } },
-  { name: '60Plusmin', range: '60Plusmin!A2:N1000', durationRange: { min: 60, max: null } },
+  { name: '0-5min', range: '0-5min!A2:N', durationRange: { min: 0, max: 5 } },
+  { name: '5-10min', range: '5-10min!A2:N', durationRange: { min: 5, max: 10 } },
+  { name: '10-20min', range: '10-20min!A2:N', durationRange: { min: 10, max: 20 } },
+  { name: '20-30min', range: '20-30min!A2:N', durationRange: { min: 20, max: 30 } },
+  { name: '30-40min', range: '30-40min!A2:N', durationRange: { min: 30, max: 40 } },
+  { name: '40-50min', range: '40-50min!A2:N', durationRange: { min: 40, max: 50 } },
+  { name: '50-60min', range: '50-60min!A2:N', durationRange: { min: 50, max: 60 } },
+  { name: '60Plusmin', range: '60Plusmin!A2:N', durationRange: { min: 60, max: null } },
 ];
 
 export const SPREADSHEET_ID = '1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU';

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -9,6 +9,7 @@ export const SHEET_TABS: SheetTab[] = [
   { name: '40-50min', range: '40-50min!A2:N', durationRange: { min: 40, max: 50 } },
   { name: '50-60min', range: '50-60min!A2:N', durationRange: { min: 50, max: 60 } },
   { name: '60Plusmin', range: '60Plusmin!A2:N', durationRange: { min: 60, max: null } },
+  { name: 'Inconnue', range: 'Inconnue!A2:N', durationRange: { min: null, max: null } },
 ];
 
 export const SPREADSHEET_ID = '1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU';


### PR DESCRIPTION
## Summary
- widen Google Sheets ranges to include all rows by using open-ended A2:N references

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build`
- `node -e "fetch('https://sheets.googleapis.com/v4/spreadsheets/1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU/values/0-5min!A2:N1000?key=AIzaSyDHa0ZENKhJVKbeBMDewGosfvA0kB_uTBY').then(r=>r.json()).then(d=>console.log(d.values.length)).catch(console.error)"` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3791666c8320aecb7ed457506302