### PR TITLE
Add channel avatar and category columns to exported videos

### DIFF
--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+def test_headers_contains_avatar_and_category():
+    assert "Avatar" in main.HEADERS
+    assert "Catégorie" in main.HEADERS


### PR DESCRIPTION
## Summary
- include channel avatar URL and category in video rows and headers
- fetch channel avatars via YouTube API with caching
- add tests ensuring new columns exist

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af353110d08320bded264359c1e629