### PR TITLE
feat: support multiple Google Sheet ranges

### DIFF
--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -49,8 +49,8 @@ jobs:
         env:
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
-          # Specify only the cell range without a sheet name so the API uses the first sheet by default
-          SHEET_RANGE: A1:Z1000  # adapt the range if needed
+          # Comma-separated list of sheet ranges to merge
+          SHEET_RANGE: "0-5min!A1:Z,5-10min!A1:Z,10-15min!A1:Z"  # adapt the ranges if needed
         run: python scripts/export_sheet.py
 
       - name: Commit updated data

--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -2,11 +2,27 @@ import os
 import json
 import csv
 import pathlib
+from typing import Iterable, List
+
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
+
+def parse_ranges(raw: str) -> List[str]:
+    """Return a list of sheet ranges from env string.
+
+    Accepts either a comma-separated string ("Tab1!A1:Z,Tab2!A1:Z") or a JSON
+    array ("['Tab1!A1:Z', 'Tab2!A1:Z']").
+    """
+
+    raw = raw.strip()
+    if raw.startswith("["):
+        return [s.strip() for s in json.loads(raw)]
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
 SPREADSHEET_ID = os.environ["SPREADSHEET_ID"]
-SHEET_RANGE = os.environ.get("SHEET_RANGE", "AllVideos!A1:Z")  # adjust the sheet name if needed
+SHEET_RANGES = parse_ranges(os.environ.get("SHEET_RANGE", "AllVideos!A1:Z"))
 
 # Read credentials from environment secret
 creds_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
@@ -16,10 +32,19 @@ creds = service_account.Credentials.from_service_account_info(
 )
 
 service = build("sheets", "v4", credentials=creds)
-resp = service.spreadsheets().values().get(
-    spreadsheetId=SPREADSHEET_ID, range=SHEET_RANGE
-).execute()
-values = resp.get("values", [])
+
+all_values: List[Iterable[str]] = []
+for idx, sheet_range in enumerate(SHEET_RANGES):
+    resp = service.spreadsheets().values().get(
+        spreadsheetId=SPREADSHEET_ID, range=sheet_range
+    ).execute()
+    values = resp.get("values", [])
+    if not values:
+        continue
+    if idx == 0:
+        all_values.extend(values)
+    else:
+        all_values.extend(values[1:])
 
 out_dir = pathlib.Path("bolt-app/public/data")
 out_dir.mkdir(parents=True, exist_ok=True)
@@ -28,13 +53,13 @@ out_dir.mkdir(parents=True, exist_ok=True)
 csv_path = out_dir / "videos.csv"
 with open(csv_path, "w", newline="", encoding="utf-8") as csvfile:
     writer = csv.writer(csvfile)
-    writer.writerows(values)
+    writer.writerows(all_values)
 
 # Save JSON
 json_path = out_dir / "videos.json"
 with open(json_path, "w", encoding="utf-8") as jsonfile:
-    json.dump(values, jsonfile, ensure_ascii=False, indent=2)
+    json.dump(all_values, jsonfile, ensure_ascii=False, indent=2)
 
 # Print lines for debugging
-for row in values:
+for row in all_values:
     print(row)


### PR DESCRIPTION
## Summary
- allow export script to accept comma-separated list of sheet ranges and merge results
- update export workflow to provide multiple sheet ranges

## Testing
- `python -m py_compile scripts/export_sheet.py`
- `pytest`
- `pip install flake8 yamllint` *(fails: Could not find a version...)*
- `pip install yamllint` *(fails: Could not find a version...)*


------
https://chatgpt.com/codex/tasks/task_e_68af352975dc83208249385fa9d4a17e