### PR TITLE
ci: verify deploy build output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
         working-directory: bolt-app
         run: npm run build
 
+      - name: Verify build output
+        run: ls -R bolt-app/dist
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
## Summary
- verify deploy build output before upload

## Testing
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68af3837cd6883209dc314b3e19ccad5