### PR TITLE
Handle unlimited Google Sheets ranges

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -1,0 +1,20 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchSheetData } from './fetch.ts';
+
+// Verify that fetchSheetData correctly handles ranges without an upper bound
+// and returns all available rows.
+test('fetchSheetData retrieves all rows for unbounded range', async () => {
+  const rows = Array.from({ length: 1201 }, () => ['value']);
+
+  mock.method(globalThis as any, 'fetch', async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    assert.ok(url.includes(encodeURIComponent('tab!A2:N')));
+    return new Response(JSON.stringify({ values: rows }), { status: 200 });
+  });
+
+  const result = await fetchSheetData('tab!A2:N');
+  assert.equal(result.values.length, 1201);
+
+  mock.restoreAll();
+});

--- a/bolt-app/src/utils/api/sheets/fetch.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.ts
@@ -1,5 +1,5 @@
-import { SheetResponse } from './types';
-import { SPREADSHEET_ID, API_KEY } from '../../constants';
+import type { SheetResponse } from './types.ts';
+import { SPREADSHEET_ID, API_KEY } from '../../constants.ts';
 
 const RATE_LIMIT = {
   requests: 0,

--- a/bolt-app/src/utils/api/sheets/index.ts
+++ b/bolt-app/src/utils/api/sheets/index.ts
@@ -1,6 +1,6 @@
-import { VideoData } from '../../../types/video';
-import { ApiResponse } from './types';
-import { synchronizeSheets } from './sync';
+import type { VideoData } from '../../../types/video.ts';
+import type { ApiResponse } from './types.ts';
+import { synchronizeSheets } from './sync.ts';
 
 export async function fetchAllVideos(): Promise<ApiResponse<VideoData[]>> {
   try {

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -1,0 +1,37 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { synchronizeSheets } from './sync.ts';
+import { SHEET_TABS } from '../../constants.ts';
+
+// Ensure the sheet synchronization can handle more than 1000 rows
+// by mocking the global fetch to return 1201 unique entries.
+test('synchronizeSheets handles large sheet ranges', async () => {
+  const rows = Array.from({ length: 1201 }, (_, i) => [
+    'https://example.com/avatar.jpg',
+    `Title ${i}`,
+    `https://www.youtube.com/watch?v=${i}`,
+    'Channel',
+    '2020-01-01T00:00:00Z',
+    'PT10M',
+    '100',
+    '10',
+    '1',
+    'Description',
+    'tag',
+    'Category',
+    'https://example.com/thumb.jpg'
+  ]);
+
+  // Limit to a single tab to simplify the mock
+  SHEET_TABS.length = 1;
+  SHEET_TABS[0].range = 'tab!A2:N';
+
+  mock.method(globalThis, 'fetch', async () => {
+    return new Response(JSON.stringify({ values: rows }), { status: 200 });
+  });
+
+  const videos = await synchronizeSheets();
+  assert.equal(videos.length, 1201);
+
+  mock.restoreAll();
+});

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -1,8 +1,8 @@
-import { fetchSheetData } from './fetch';
-import { SHEET_TABS } from '../../constants';
-import { VideoData } from '../../../types/video';
-import { validateRow } from './validation';
-import { processVideoData } from '../../youtube';
+import { fetchSheetData } from './fetch.ts';
+import { SHEET_TABS } from '../../constants.ts';
+import type { VideoData } from '../../../types/video.ts';
+import { validateRow } from './validation.ts';
+import { processVideoData } from '../../youtube.ts';
 
 interface VideoMap {
   [link: string]: VideoData;

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -1,4 +1,4 @@
-import { VideoData } from '../../../types/video';
+import type { VideoData } from '../../../types/video.ts';
 
 export function mapRowToVideo(row: any[]): VideoData {
   const safeString = (value: any, defaultValue: string = ''): string => {

--- a/bolt-app/src/utils/api/sheets/validation.ts
+++ b/bolt-app/src/utils/api/sheets/validation.ts
@@ -1,4 +1,4 @@
-import { VideoData } from '../../../types/video';
+import type { VideoData } from '../../../types/video.ts';
 
 export function validateRow(row: any[]): boolean {
   if (!Array.isArray(row)) {

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -1,15 +1,15 @@
-import { SheetTab } from '../types/sheets';
+import type { SheetTab } from '../types/sheets.ts';
 
 export const SHEET_TABS: SheetTab[] = [
-  { name: '0-5min', range: '0-5min!A2:N1000', durationRange: { min: 0, max: 5 } },
-  { name: '5-10min', range: '5-10min!A2:N1000', durationRange: { min: 5, max: 10 } },
-  { name: '10-20min', range: '10-20min!A2:N1000', durationRange: { min: 10, max: 20 } },
-  { name: '20-30min', range: '20-30min!A2:N1000', durationRange: { min: 20, max: 30 } },
-  { name: '30-40min', range: '30-40min!A2:N1000', durationRange: { min: 30, max: 40 } },
-  { name: '40-50min', range: '40-50min!A2:N1000', durationRange: { min: 40, max: 50 } },
-  { name: '50-60min', range: '50-60min!A2:N1000', durationRange: { min: 50, max: 60 } },
-  { name: '60Plusmin', range: '60Plusmin!A2:N1000', durationRange: { min: 60, max: null } },
-  { name: 'Inconnue', range: 'Inconnue!A2:N1000', durationRange: { min: null, max: null } },
+  { name: '0-5min', range: '0-5min!A2:N', durationRange: { min: 0, max: 5 } },
+  { name: '5-10min', range: '5-10min!A2:N', durationRange: { min: 5, max: 10 } },
+  { name: '10-20min', range: '10-20min!A2:N', durationRange: { min: 10, max: 20 } },
+  { name: '20-30min', range: '20-30min!A2:N', durationRange: { min: 20, max: 30 } },
+  { name: '30-40min', range: '30-40min!A2:N', durationRange: { min: 30, max: 40 } },
+  { name: '40-50min', range: '40-50min!A2:N', durationRange: { min: 40, max: 50 } },
+  { name: '50-60min', range: '50-60min!A2:N', durationRange: { min: 50, max: 60 } },
+  { name: '60Plusmin', range: '60Plusmin!A2:N', durationRange: { min: 60, max: null } },
+  { name: 'Inconnue', range: 'Inconnue!A2:N', durationRange: { min: null, max: null } },
 ];
 
 export const SPREADSHEET_ID = '1ltnNUqmBjkCLmePBJgM5U3yf_CU44vDucDQ9Gq8FNzU';

--- a/bolt-app/src/utils/youtube.ts
+++ b/bolt-app/src/utils/youtube.ts
@@ -1,4 +1,4 @@
-import { VideoData } from '../types/video';
+import type { VideoData } from '../types/video.ts';
 
 // Supported YouTube URL patterns
 const URL_PATTERNS = {


### PR DESCRIPTION
## Summary
- Remove 1000-row limit by using open-ended `A2:N` ranges
- Support TypeScript ESM imports and add tests for unbounded sheet ranges
- Verify synchronization returns all rows for large datasets

## Testing
- `npm test`
- `pytest`
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68af352c1b1483209a07dc1927626bfa