### PR TITLE
Specify sheet name in SHEET_RANGE and validate ranges

### DIFF
--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -50,7 +50,7 @@ jobs:
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
           # Comma-separated list of sheet ranges to merge
-          SHEET_RANGE: "0-5min!A1:Z,5-10min!A1:Z,10-15min!A1:Z"  # adapt the ranges if needed
+          SHEET_RANGE: "AllVideos!A1:Z1000"  # adapt the range if needed
         run: python scripts/export_sheet.py
 
       - name: Commit updated data

--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -23,6 +23,11 @@ def parse_ranges(raw: str) -> List[str]:
 
 SPREADSHEET_ID = os.environ["SPREADSHEET_ID"]
 SHEET_RANGES = parse_ranges(os.environ.get("SHEET_RANGE", "AllVideos!A1:Z"))
+for sheet_range in SHEET_RANGES:
+    if "!" not in sheet_range:
+        raise ValueError(
+            f"SHEET_RANGE '{sheet_range}' must include a sheet name (e.g., 'Sheet1!A1:Z1000')"
+        )
 
 # Read credentials from environment secret
 creds_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])


### PR DESCRIPTION
## Summary
- explicitly include sheet name in `SHEET_RANGE` for export workflow
- raise error when `SHEET_RANGE` lacks a sheet name

## Testing
- `ruff check scripts/export_sheet.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af39e259b88320948bad8e931295e9