### PR TITLE
feat: expand sheet columns with channel avatar and thumbnail

### DIFF
--- a/bolt-app/src/utils/api/sheets.ts
+++ b/bolt-app/src/utils/api/sheets.ts
@@ -36,7 +36,7 @@ async function fetchSheetData(range: string): Promise<any[]> {
 function validateVideoData(row: any[]): boolean {
   return (
     Array.isArray(row) &&
-    row.length >= 12 &&
+    row.length >= 13 &&
     typeof row[1] === 'string' && // Titre
     typeof row[2] === 'string' && // Lien
     row[1].trim() !== '' &&
@@ -46,7 +46,7 @@ function validateVideoData(row: any[]): boolean {
 
 function mapRowToVideo(row: any[]): VideoData {
   return {
-    thumbnail: String(row[0] || ''),
+    channelAvatar: String(row[0] || ''),
     title: String(row[1] || ''),
     link: String(row[2] || ''),
     channel: String(row[3] || ''),
@@ -57,7 +57,8 @@ function mapRowToVideo(row: any[]): VideoData {
     comments: String(row[8] || '0'),
     shortDescription: String(row[9] || ''),
     tags: String(row[10] || ''),
-    category: String(row[11] || '')
+    category: String(row[11] || ''),
+    thumbnail: String(row[12] || ''),
   };
 }
 

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -87,7 +87,8 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
           comments,
           description,
           tags,
-          category
+          category,
+          thumbnail
         ] = row.map(cell => String(cell || '').trim());
 
         if (!link || !link.includes('youtube.com')) {
@@ -109,7 +110,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
             shortDescription: description || '',
             tags: tags || '',
             category: category || 'Non catégorisé',
-            thumbnail: ''
+            thumbnail: thumbnail || ''
           };
 
           videoMap[link] = processVideoData(video);

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -9,10 +9,10 @@ export function mapRowToVideo(row: any[]): VideoData {
   };
 
   return {
-    thumbnail: safeString(row[12]), // Column M for thumbnail
-    title: safeString(row[1]),      // Column B
-    link: safeString(row[2]),       // Column C
-    channel: safeString(row[3]),    // Column D
+    channelAvatar: safeString(row[0]), // Column A
+    title: safeString(row[1]),        // Column B
+    link: safeString(row[2]),         // Column C
+    channel: safeString(row[3]),      // Column D
     publishedAt: safeString(row[4], new Date().toISOString()),
     duration: safeString(row[5], '00:00'),
     views: safeString(row[6], '0'),
@@ -21,7 +21,6 @@ export function mapRowToVideo(row: any[]): VideoData {
     shortDescription: safeString(row[9]),
     tags: safeString(row[10]),
     category: safeString(row[11], 'Non catégorisé'), // Column L for category
-    channelAvatar: safeString(row[0]), // Column A
-    addedAt: safeString(row[13], new Date().toISOString())
+    thumbnail: safeString(row[12]), // Column M for thumbnail
   };
 }

--- a/main.py
+++ b/main.py
@@ -9,12 +9,10 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 HEADERS = [
-    "Miniature",
+    "Avatar",
     "Titre",
     "Lien",
     "Chaîne",
-    "Avatar",
-    "Catégorie",
     "Publié le",
     "Durée",
     "Vues",
@@ -22,6 +20,8 @@ HEADERS = [
     "Commentaires",
     "Description courte",
     "Tags",
+    "Catégorie",
+    "Miniature",
 ]
 
 def parse_duration(iso_duration):
@@ -251,12 +251,10 @@ def sync_videos():
 
         category = get_duration_category(video_duration)
         videos_by_category[category].append([
-            thumbnail_formula,
+            avatar_url,
             title,
             video_link,
             channel,
-            avatar_url,
-            category,
             published_at_formatted,
             video_duration,
             view_count,
@@ -264,6 +262,8 @@ def sync_videos():
             comment_count,
             short_description,
             tags_str,
+            category,
+            thumbnail_formula,
         ])
 
     # Titres des colonnes
@@ -273,8 +273,9 @@ def sync_videos():
         # Mélange aléatoire des vidéos dans la catégorie
         random.shuffle(videos)
 
-        RANGE_NAME_DATA = f"'{category}'!A2:M"
-        RANGE_NAME_HEADERS = f"'{category}'!A1:M1"
+        last_col = chr(ord('A') + len(headers) - 1)
+        RANGE_NAME_DATA = f"'{category}'!A2:{last_col}"
+        RANGE_NAME_HEADERS = f"'{category}'!A1:{last_col}1"
 
         # Création de la feuille si elle n'existe pas déjà
         try:
@@ -329,7 +330,7 @@ def sync_videos():
                             "startRowIndex": 0,
                             "endRowIndex": 1,
                             "startColumnIndex": 0,
-                            "endColumnIndex": 13
+                            "endColumnIndex": len(headers)
                         },
                         "cell": {
                             "userEnteredFormat": {
@@ -380,7 +381,7 @@ def sync_videos():
                             "sheetId": sheet_id,
                             "dimension": "COLUMNS",
                             "startIndex": 0,
-                            "endIndex": 13
+                            "endIndex": len(headers)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- add channel avatar and video thumbnail columns and reorganize sheet headers
- generate range bounds and formatting dynamically from header length
- update TypeScript sheet utilities for new column order

## Testing
- `pytest`
- `npm test`
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68af39e4e688832094ce04b2fd085e0a