### PR TITLE
Add aggregate AllVideos sheet and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Synchronisation des vidéos d’une playlist YouTube vers Google Sheets.
 
+Les vidéos sont réparties dans des onglets selon leur durée et un onglet
+supplémentaire **AllVideos** regroupe l'intégralité des entrées.
+
 ## Planification
 
 Synchronisation automatique aux heures suivantes (heure de Paris) :

--- a/tests/test_all_videos.py
+++ b/tests/test_all_videos.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+# Ajoute le répertoire parent au chemin pour pouvoir importer main
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import main
+
+
+def test_all_videos_length_matches_sum():
+    videos_by_category = {"0-5min": [], "5-10min": []}
+    all_videos = []
+
+    main.add_video_to_categories(["video1"], "0-5min", videos_by_category, all_videos)
+    main.add_video_to_categories(["video2"], "5-10min", videos_by_category, all_videos)
+    main.add_video_to_categories(["video3"], "5-10min", videos_by_category, all_videos)
+
+    total = sum(len(v) for v in videos_by_category.values())
+    assert len(all_videos) == total


### PR DESCRIPTION
## Summary
- collect videos in a global list while categorizing by duration
- create an `AllVideos` sheet mirroring other tabs and insert all videos
- document the new `AllVideos` sheet and add unit test for list aggregation

## Testing
- `flake8` *(fails: could not install flake8)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af3f67711c8320aa37cf502fffeedd