### PR TITLE
Fix thumbnail and avatar column mappings

### DIFF
--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -1,5 +1,5 @@
 export interface VideoData {
-  channelAvatar: string;   // Colonne A
+  thumbnail: string;      // Colonne A
   title: string;          // Colonne B
   link: string;           // Colonne C
   channel: string;        // Colonne D
@@ -11,7 +11,7 @@ export interface VideoData {
   shortDescription: string; // Colonne J
   tags: string;           // Colonne K
   category: string;       // Colonne L
-  thumbnail: string;      // Générée à partir du lien YouTube
+  channelAvatar: string;  // Colonne M
 }
 
 export interface VideoResponse {

--- a/bolt-app/src/utils/api/sheets.ts
+++ b/bolt-app/src/utils/api/sheets.ts
@@ -45,7 +45,7 @@ function validateVideoData(row: any[]): boolean {
 
 function mapRowToVideo(row: any[]): VideoData {
   return {
-    channelAvatar: String(row[0] || ''),
+    thumbnail: String(row[0] || ''),
     title: String(row[1] || ''),
     link: String(row[2] || ''),
     channel: String(row[3] || ''),
@@ -57,7 +57,7 @@ function mapRowToVideo(row: any[]): VideoData {
     shortDescription: String(row[9] || ''),
     tags: String(row[10] || ''),
     category: String(row[11] || ''),
-    thumbnail: String(row[12] || ''),
+    channelAvatar: String(row[12] || ''),
   };
 }
 

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -76,7 +76,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
       
       validRows.forEach(row => {
         const [
-          channelAvatar,
+          thumbnail,
           title,
           link,
           channel,
@@ -88,7 +88,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
           description,
           tags,
           category,
-          thumbnail
+          channelAvatar
         ] = row.map(cell => String(cell || '').trim());
 
         if (!link || !link.includes('youtube.com')) {
@@ -98,7 +98,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
 
         if (!videoMap[link]) {
           const video: VideoData = {
-            channelAvatar: channelAvatar || '',
+            thumbnail: thumbnail || '',
             title: title || '',
             link,
             channel: channel || '',
@@ -110,7 +110,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
             shortDescription: description || '',
             tags: tags || '',
             category: category || 'Non catégorisé',
-            thumbnail: thumbnail || ''
+            channelAvatar: channelAvatar || ''
           };
 
           videoMap[link] = processVideoData(video);

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -9,10 +9,10 @@ export function mapRowToVideo(row: any[]): VideoData {
   };
 
   return {
-    channelAvatar: safeString(row[0]), // Column A
-    title: safeString(row[1]),        // Column B
-    link: safeString(row[2]),         // Column C
-    channel: safeString(row[3]),      // Column D
+    thumbnail: safeString(row[0]), // Column A
+    title: safeString(row[1]),     // Column B
+    link: safeString(row[2]),      // Column C
+    channel: safeString(row[3]),   // Column D
     publishedAt: safeString(row[4], new Date().toISOString()),
     duration: safeString(row[5], '00:00'),
     views: safeString(row[6], '0'),
@@ -21,6 +21,6 @@ export function mapRowToVideo(row: any[]): VideoData {
     shortDescription: safeString(row[9]),
     tags: safeString(row[10]),
     category: safeString(row[11], 'Non catégorisé'), // Column L for category
-    thumbnail: safeString(row[12]), // Column M for thumbnail
+    channelAvatar: safeString(row[12]), // Column M for channel avatar
   };
 }

--- a/bolt-app/src/utils/api/sheets/validation.ts
+++ b/bolt-app/src/utils/api/sheets/validation.ts
@@ -8,14 +8,18 @@ export function validateRow(row: any[]): boolean {
 
   const title = String(row[1] || '').trim();
   const link = String(row[2] || '').trim();
-  const thumbnail = String(row[12] || '').trim(); // Validate thumbnail from column M
+  const thumbnail = String(row[0] || '').trim(); // Validate thumbnail from column A
+  const channelAvatar = String(row[12] || '').trim(); // Validate channel avatar from column M
 
   const hasTitleAndLink = title !== '' && link !== '';
-  const hasValidLinkFormat = link.startsWith('http://') || 
-                            link.startsWith('https://') || 
+  const hasValidLinkFormat = link.startsWith('http://') ||
+                            link.startsWith('https://') ||
                             link.startsWith('www.');
-  const hasValidThumbnail = thumbnail.startsWith('http://') || 
+  const hasValidThumbnail = thumbnail.startsWith('http://') ||
                            thumbnail.startsWith('https://');
+  const hasValidAvatar = channelAvatar === '' ||
+                         channelAvatar.startsWith('http://') ||
+                         channelAvatar.startsWith('https://');
 
   if (!hasValidThumbnail) {
     console.warn('Invalid thumbnail URL:', {
@@ -24,16 +28,25 @@ export function validateRow(row: any[]): boolean {
     });
   }
 
-  const isValid = hasTitleAndLink && hasValidLinkFormat;
+  if (!hasValidAvatar && channelAvatar) {
+    console.warn('Invalid channel avatar URL:', {
+      channelAvatar,
+      rowIndex: row[0] ? `Row with title ${row[1]}` : 'Unknown row'
+    });
+  }
+
+  const isValid = hasTitleAndLink && hasValidLinkFormat && hasValidThumbnail && hasValidAvatar;
 
   if (!isValid) {
     console.warn('Row validation failed:', {
       hasTitleAndLink,
       hasValidLinkFormat,
       hasValidThumbnail,
+      hasValidAvatar,
       title,
       link,
       thumbnail,
+      channelAvatar,
       reason: !hasTitleAndLink ? 'Missing title or link' : 'Invalid link format'
     });
   }


### PR DESCRIPTION
## Summary
- read thumbnail from column A and avatar from column M across sheets utilities
- adjust row validation for new thumbnail and avatar indices
- align VideoData type and sheet sync logic with updated column order

## Testing
- `npm test`
- `pytest`
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68af449aeefc8320b9ca65e1f9d80d78