### PR TITLE
refactor: reorder headers for thumbnail and avatar

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 HEADERS = [
-    "channelAvatar",
+    "thumbnail",
     "title",
     "link",
     "channel",
@@ -21,7 +21,7 @@ HEADERS = [
     "shortDescription",
     "tags",
     "category",
-    "thumbnail",
+    "channelAvatar",
 ]
 
 DEFAULT_AVATAR_URL = "https://via.placeholder.com/48"
@@ -259,7 +259,7 @@ def sync_videos():
 
         duration_category = get_duration_category(video_duration)
         entry = [
-            avatar_url,
+            thumbnail_formula,
             title,
             video_link,
             channel,
@@ -271,7 +271,7 @@ def sync_videos():
             short_description,
             tags_str,
             duration_category,
-            thumbnail_formula,
+            avatar_url,
         ]
         add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import main
 
 EXPECTED_HEADERS = [
-    "channelAvatar",
+    "thumbnail",
     "title",
     "link",
     "channel",
@@ -18,7 +18,7 @@ EXPECTED_HEADERS = [
     "shortDescription",
     "tags",
     "category",
-    "thumbnail",
+    "channelAvatar",
 ]
 
 


### PR DESCRIPTION
## Summary
- place `thumbnail` at the start of the header list and move `channelAvatar` to the end
- update row assembly to match reordered headers
- adjust tests for new header order

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af65f1f08c832084b3d65179e3c725