### PR TITLE
feat: include channel avatar in sheets mapper

### DIFF
--- a/bolt-app/src/utils/sheetsApi.ts
+++ b/bolt-app/src/utils/sheetsApi.ts
@@ -32,7 +32,8 @@ function mapRowToVideo(row: string[]): VideoData {
     comments: row[8] || '0',
     shortDescription: row[9] || '',
     tags: row[10] || '',
-    category: row[11] || ''
+    category: row[11] || '',
+    channelAvatar: row[12] || ''
   };
 }
 


### PR DESCRIPTION
## Summary
- map channel avatar from column 13 when reading rows

## Testing
- `npm test`
- `pytest`
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68af65f389cc83208da55d4ded3d6f49