### PR TITLE
Ensure channel avatars precede thumbnails in Sheets export

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 HEADERS = [
-    "thumbnail",
+    "channelAvatar",
     "title",
     "link",
     "channel",
@@ -21,7 +21,7 @@ HEADERS = [
     "shortDescription",
     "tags",
     "category",
-    "channelAvatar",
+    "thumbnail",
 ]
 
 DEFAULT_AVATAR_URL = "https://via.placeholder.com/48"
@@ -259,7 +259,7 @@ def sync_videos():
 
         duration_category = get_duration_category(video_duration)
         entry = [
-            thumbnail_formula,
+            avatar_url,
             title,
             video_link,
             channel,
@@ -271,7 +271,7 @@ def sync_videos():
             short_description,
             tags_str,
             duration_category,
-            avatar_url,
+            thumbnail_formula,
         ]
         add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import main
 
 EXPECTED_HEADERS = [
-    "thumbnail",
+    "channelAvatar",
     "title",
     "link",
     "channel",
@@ -18,7 +18,7 @@ EXPECTED_HEADERS = [
     "shortDescription",
     "tags",
     "category",
-    "channelAvatar",
+    "thumbnail",
 ]
 
 


### PR DESCRIPTION
## Summary
- Reorder column headers so channel avatars appear first and thumbnails last
- Adjust exported row assembly to match new header order
- Update tests to reflect new header arrangement

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af91cfa5bc832093fa2ee53212755e