### PR TITLE
feat: add theme toggle

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -7,6 +7,7 @@ import { SortSelect } from './components/SortSelect';
 import { LoadingState } from './components/LoadingState';
 import { ErrorState } from './components/ErrorState';
 import { SoundToggle } from './components/ui/SoundToggle';
+import { ThemeToggle } from './components/ui/ThemeToggle';
 import { SHEET_TABS } from './utils/constants';
 import { filterVideosByDuration } from './utils/videoFilters';
 import { filterVideosBySearch } from './utils/searchUtils';
@@ -107,7 +108,10 @@ export default function App() {
                   />
                 </h1>
               </button>
-              <SoundToggle />
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+                <SoundToggle />
+              </div>
             </div>
 
             {!isLoading && !error && (

--- a/bolt-app/src/components/ui/ThemeToggle.tsx
+++ b/bolt-app/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '../../hooks/useTheme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-700 transition-colors"
+      title={theme === 'dark' ? 'Activer le thème clair' : 'Activer le thème sombre'}
+    >
+      {theme === 'dark' ? (
+        <Sun className="w-5 h-5" />
+      ) : (
+        <Moon className="w-5 h-5" />
+      )}
+    </button>
+  );
+}
+

--- a/bolt-app/src/hooks/useTheme.ts
+++ b/bolt-app/src/hooks/useTheme.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored === 'light' || stored === 'dark') {
+        return stored;
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return { theme, toggleTheme };
+}
+

--- a/bolt-app/tailwind.config.js
+++ b/bolt-app/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  darkMode: 'media',
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- switch Tailwind to class-based dark mode
- add theme hook with localStorage persistence and root class toggling
- provide ThemeToggle component and integrate into header

## Testing
- `npm run lint` (fails: Cannot find package 'globals')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b034b2a7948320b1e21e6e88d34677