### PR TITLE
feat: show optional channel avatar

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -43,17 +43,25 @@ export function VideoCard({ video }: VideoCardProps) {
           {video.title}
         </h3>
         
-        <div className="text-[13px] text-youtube-gray-dark dark:text-gray-400">
-          {video.channel}
-        </div>
-        
-        <div className="flex items-center gap-1 text-[13px] text-youtube-gray-dark dark:text-gray-400 mt-1">
-          <span className="flex items-center gap-1">
-            <Eye className="w-3.5 h-3.5" />
-            {formatNumber(video.views)}
-          </span>
-          <span className="mx-1">•</span>
-          <span>{formatPublishDate(video.publishedAt)}</span>
+        <div className="flex items-start text-[13px] text-youtube-gray-dark dark:text-gray-400">
+          {video.channelAvatar && (
+            <img
+              src={video.channelAvatar}
+              alt={`${video.channel} avatar`}
+              className="w-6 h-6 rounded-full mr-2"
+            />
+          )}
+          <div>
+            <div>{video.channel}</div>
+            <div className="flex items-center gap-1 mt-1">
+              <span className="flex items-center gap-1">
+                <Eye className="w-3.5 h-3.5" />
+                {formatNumber(video.views)}
+              </span>
+              <span className="mx-1">•</span>
+              <span>{formatPublishDate(video.publishedAt)}</span>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- display optional channel avatar to the left of video metadata
- group channel name and stats in a flex container for two-line layout

## Testing
- `npm run lint` (fails: Cannot find package 'globals')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b036ef346c8320bd238b236dcb5e58