### PR TITLE
refactor: switch VideoCard channel info to grid

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -43,24 +43,22 @@ export function VideoCard({ video }: VideoCardProps) {
           {video.title}
         </h3>
         
-        <div className="flex items-start text-[13px] text-youtube-gray-dark dark:text-gray-400">
+        <div className="grid grid-cols-[auto_1fr] items-start text-[13px] text-youtube-gray-dark dark:text-gray-400">
           {video.channelAvatar && (
             <img
               src={video.channelAvatar}
               alt={`${video.channel} avatar`}
-              className="w-6 h-6 rounded-full mr-2"
+              className="w-6 h-6 rounded-full mr-2 row-span-2"
             />
           )}
-          <div>
-            <div>{video.channel}</div>
-            <div className="flex items-center gap-1 mt-1">
-              <span className="flex items-center gap-1">
-                <Eye className="w-3.5 h-3.5" />
-                {formatNumber(video.views)}
-              </span>
-              <span className="mx-1">•</span>
-              <span>{formatPublishDate(video.publishedAt)}</span>
-            </div>
+          <div className="col-start-2">{video.channel}</div>
+          <div className="col-span-2 flex items-center gap-1 mt-1">
+            <span className="flex items-center gap-1">
+              <Eye className="w-3.5 h-3.5" />
+              {formatNumber(video.views)}
+            </span>
+            <span className="mx-1">•</span>
+            <span>{formatPublishDate(video.publishedAt)}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use CSS grid for channel avatar, name, and metadata in VideoCard

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b038da934883208a88a647833b840d