### PR TITLE
Handle undefined values in video search

### DIFF
--- a/bolt-app/src/utils/searchUtils.ts
+++ b/bolt-app/src/utils/searchUtils.ts
@@ -10,7 +10,7 @@ export function filterVideosBySearch(videos: VideoData[], filters: SearchFilters
   
   return videos.filter(video => {
     return filters.fields.some(field => {
-      const value = video[field].toLowerCase();
+      const value = (video[field] ?? '').toLowerCase();
       return value.includes(searchTerm);
     });
   });


### PR DESCRIPTION
## Summary
- prevent search from crashing by casting field values to string before calling `toLowerCase`

## Testing
- `npm test`
- `npm run build`
- `pytest`
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68b0405c805c83208b7142e2a5839cef