### PR TITLE
feat(ui): show check icon for selected dropdown item

### DIFF
--- a/bolt-app/src/components/ui/DropdownItem.tsx
+++ b/bolt-app/src/components/ui/DropdownItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CheckCircle } from 'lucide-react';
 
 interface DropdownItemProps {
   onClick: () => void;
@@ -17,7 +18,10 @@ export function DropdownItem({ onClick, isSelected, children }: DropdownItemProp
         }
       `}
     >
-      {children}
+      {isSelected && (
+        <CheckCircle className="w-4 h-4 mr-2 inline-block align-middle" />
+      )}
+      <span className="align-middle">{children}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- add lucide-react CheckCircle icon when dropdown item is selected
- align dropdown item text with optional icon

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05483fa088320af868280cac7f183