### PR TITLE
fix deploy workflow and add globals dev dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,21 +26,18 @@ jobs:
 
       - name: Set up Node
         uses: actions/setup-node@v4
-        with
-          node-versio:l
+        with:
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: bolt-app/package-lock.json
 
       - name: Install dependencies
         working-directory: bolt-app
-        run: npm install
+        run: npm ci
 
       - name: Build
         working-directory: bolt-app
         run: npm run build
-
-      - name: Verify build output
-        run: ls -R bolt-app/dist
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -55,5 +52,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-https://github.dev/SylvainWinning/youtube-to-sheets
-

--- a/bolt-app/package.json
+++ b/bolt-app/package.json
@@ -28,6 +28,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "globals": "^14.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- fix Node setup in deploy workflow and use npm ci
- remove obsolete verify build step
- add globals as dev dependency

## Testing
- `npm test` (bolt-app)
- `npm run lint` (bolt-app) *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'globals')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b06aba23cc8320a7d46ca926f54308