### PR TITLE
fix deploy workflow and add globals dev dependency

### DIFF
--- a/bolt-app/package-lock.json
+++ b/bolt-app/package-lock.json
@@ -4347,7 +4347,7 @@
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "",
+      "integrity": "sha512-lOm3NhaGhcJBa1QJ+jKrizXBpD5nUOc/kMpmUhnthiNuR9qSFUemPdPqIu3ciABQBpKCGf4tNlpMrYhf9qsUkw==",
       "dev": true
     }
   }


### PR DESCRIPTION
## Summary
- fix Node setup in deploy workflow and use npm ci
- remove obsolete verify build step
- add globals dev dependency and sync lockfile
- restore integrity hash for globals in lockfile

## Testing
- `npm test` (bolt-app)
- `npm run lint` (bolt-app) *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typescript-eslint')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b07ede6ae88320b68ba40afad4334b