### PR TITLE
feat: enable workflow auto cancellation

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -97,7 +97,7 @@ permissions:
 
 concurrency:
   group: youtube-to-sheets-sync
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary
- allow concurrent runs to cancel in-progress sync workflow

## Testing
- `pytest`
- ❌ `flake8` *(command not found: flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68b08292b33083208ae70dbed1f7ece7