### PR TITLE
Fix duration category labels, date format, and dependency pins

### DIFF
--- a/bolt-app/package.json
+++ b/bolt-app/package.json
@@ -29,6 +29,6 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "vite": "^5.4.2",
-    "globals":  "^16.3.0"
+    "globals": "^14.0.0"
   }
 }

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def parse_duration(iso_duration):
     return f"{h:02d}:{m:02d}:{s:02d}"
 
 def get_duration_category(duration):
-    """Classe la durée en catégories (0‑5 min, 5‑10 min, etc.)."""
+    """Classe la durée en catégories (0-5 min, 5-10 min, etc.)."""
     parts = duration.split(":")
     if len(parts) != 3:
         return "Inconnue"
@@ -52,21 +52,21 @@ def get_duration_category(duration):
         return "Inconnue"
     total_seconds = h * 3600 + m * 60 + s
     if total_seconds <= 300:
-        return "0‑5min"
+        return "0-5min"
     elif total_seconds <= 600:
-        return "5‑10min"
+        return "5-10min"
     elif total_seconds <= 1200:
-        return "10‑20min"
+        return "10-20min"
     elif total_seconds <= 1800:
-        return "20‑30min"
+        return "20-30min"
     elif total_seconds <= 2400:
-        return "30‑40min"
+        return "30-40min"
     elif total_seconds <= 3000:
-        return "40‑50min"
+        return "40-50min"
     elif total_seconds <= 3600:
-        return "50‑60min"
+        return "50-60min"
     else:
-        return "60plussmin"
+        return "60Plusmin"
 
 def get_sheet_id(spreadsheet_id, sheet_title, service):
     """Retourne l’ID de feuille correspondant au titre dans un Google Sheet."""
@@ -116,9 +116,9 @@ def get_thumbnail_url(video_data):
     return DEFAULT_THUMBNAIL_URL
 
 def format_published_at(iso_timestamp):
-    """Formate la date de publication ISO en 'dd/mm/aa hh:mm:ss' (préfixée d’une apostrophe)."""
+    """Formate la date de publication ISO en 'dd/mm/YYYY HH:MM' (préfixée d'une apostrophe)."""
     dt = datetime.strptime(iso_timestamp, "%Y-%m-%dT%H:%M:%SZ")
-    return f"'{dt.strftime('%d/%m/%y %H:%M:%S')}"
+    return f"'{dt.strftime('%d/%m/%Y %H:%M')}"
 
 # Cache d’avatars de chaîne (évite de refaire des requêtes)
 channel_avatar_cache = {}
@@ -181,14 +181,14 @@ def sync_videos():
 
     # Catégories de durée
     videos_by_category = {
-        "0‑5min": [],
-        "5‑10min": [],
-        "10‑20min": [],
-        "20‑30min": [],
-        "30‑40min": [],
-        "40‑50min": [],
-        "50‑60min": [],
-        "60plussmin": [],
+        "0-5min": [],
+        "5-10min": [],
+        "10-20min": [],
+        "20-30min": [],
+        "30-40min": [],
+        "40-50min": [],
+        "50-60min": [],
+        "60Plusmin": [],
         "Inconnue": [],
     }
     all_videos = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-google-api-python-client==2.178.0
-google-auth==2.40.3
-google-auth-httplib2==0.2.0
-google-auth-oauthlib==1.2.0
-requests==2.32.4
+google-api-python-client>=2.0.0,<3.0.0
+google-auth>=2.0.0,<3.0.0
+google-auth-httplib2>=0.2.0,<1.0.0
+google-auth-oauthlib>=1.2.0,<2.0.0
+requests>=2.0.0,<3.0.0


### PR DESCRIPTION
## Summary
- use standard hyphens for duration category labels and add missing `60Plusmin` category
- format published dates as `'dd/mm/YYYY HH:MM` without seconds
- relax dependency pins in requirements to avoid install failures during sync
- align Node `globals` dev dependency with lock file to stabilize `npm ci`

## Testing
- `npm ci` *(fails: 403 Forbidden to registry)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d2bcf7dc832086c753279130ada8