### PR TITLE
chore: refine CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       # 1. Récupère le dépôt
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0      # nécessaire pour l’historique complet
 

--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -45,9 +45,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: "pip"
 
       - name: Install deps
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Export sheet to CSV/JSON
         env:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -123,6 +123,7 @@ jobs:
 
   sync:
     name: Sync playlist to Google Sheets
+    needs: tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- upgrade deployment workflow to latest checkout action
- speed up export workflow with pip caching and upgrades
- gate playlist sync on tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e48ecbd48320bd25730b09f003d7