### PR TITLE
Batch video detail requests to speed up sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,6 +96,8 @@ def fetch_all_playlist_items(playlist_id, api_key):
             resp = requests.get(base_url, params=params, timeout=10)
             resp.raise_for_status()
             data = resp.json()
+            attempts = 0
+            backoff = 1
         except requests.exceptions.HTTPError as err:
             status = err.response.status_code if err.response else None
             if status == 404:


### PR DESCRIPTION
## Summary
- Fetch video details in batches to avoid making an API call per video
- Use the batched data in `sync_videos` and simplify thumbnail extraction
- Abort playlist fetch after repeated errors and stop retrying on 404
- Reset playlist fetch retry counters after successful page loads to avoid aborting on isolated errors

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0eeeb3e1c832092cdb6e179af5c07