### PR TITLE
fix: cap YouTube API retries to avoid endless sync

### DIFF
--- a/tests/test_channel_avatar.py
+++ b/tests/test_channel_avatar.py
@@ -1,0 +1,41 @@
+import requests
+from main import get_channel_avatar, DEFAULT_AVATAR_URL, channel_avatar_cache
+
+
+def test_get_channel_avatar_success(monkeypatch):
+    channel_avatar_cache.clear()
+
+    def fake_get(url, timeout):
+        class Response:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {
+                    "items": [
+                        {
+                            "snippet": {
+                                "thumbnails": {
+                                    "default": {"url": "http://example.com/avatar.jpg"}
+                                }
+                            }
+                        }
+                    ]
+                }
+
+        return Response()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    url = get_channel_avatar("abc", api_key="key")
+    assert url == "http://example.com/avatar.jpg"
+
+
+def test_get_channel_avatar_error_returns_default(monkeypatch):
+    channel_avatar_cache.clear()
+
+    def fake_get(url, timeout):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    url = get_channel_avatar("abc", api_key="key")
+    assert url == DEFAULT_AVATAR_URL

--- a/tests/test_fetch_retries.py
+++ b/tests/test_fetch_retries.py
@@ -1,0 +1,28 @@
+import requests
+from main import fetch_all_playlist_items, fetch_videos_details
+
+
+def test_fetch_all_playlist_items_max_retries(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_get(url, params=None, timeout=None):
+        calls["count"] += 1
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    items = fetch_all_playlist_items("playlist", "key", max_retries=3)
+    assert items == []
+    assert calls["count"] == 3
+
+
+def test_fetch_videos_details_max_retries(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_get(url, params=None, timeout=None):
+        calls["count"] += 1
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    details = fetch_videos_details(["id1"], "key", max_retries=3)
+    assert details == {}
+    assert calls["count"] == 3


### PR DESCRIPTION
## Summary
- limit YouTube playlist and video fetches to a maximum number of retries
- validate required environment variables before starting sync
- add tests covering retry caps

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1687195588320b088a79f8febdc88