### PR TITLE
fix: align channel avatar with name

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -43,16 +43,18 @@ export function VideoCard({ video }: VideoCardProps) {
           {video.title}
         </h3>
         
-        <div className="grid grid-cols-[auto_1fr] items-start text-[13px] text-youtube-gray-dark dark:text-gray-400">
-          {video.channelAvatar && (
-            <img
-              src={video.channelAvatar}
-              alt={`${video.channel} avatar`}
-              className="w-6 h-6 rounded-full mr-2 row-span-2"
-            />
-          )}
-          <div className="col-start-2">{video.channel}</div>
-          <div className="col-span-2 flex items-center gap-1 mt-1">
+        <div className="text-[13px] text-youtube-gray-dark dark:text-gray-400">
+          <div className="flex items-center mb-1">
+            {video.channelAvatar && (
+              <img
+                src={video.channelAvatar}
+                alt={`${video.channel} avatar`}
+                className="w-6 h-6 rounded-full mr-2"
+              />
+            )}
+            <span>{video.channel}</span>
+          </div>
+          <div className="flex items-center gap-1">
             <span className="flex items-center gap-1">
               <Eye className="w-3.5 h-3.5" />
               {formatNumber(video.views)}


### PR DESCRIPTION
## Summary
- keep channel avatar and name on same row
- show views and publish date on their own line under channel name

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint'; npm install attempt returned 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17d151e088320a82e4f79d30616bf