### PR TITLE
fix: center channel avatar with name

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -43,21 +43,23 @@ export function VideoCard({ video }: VideoCardProps) {
           {video.title}
         </h3>
         
-        <div className="grid grid-cols-[auto_1fr] items-start text-[13px] text-youtube-gray-dark dark:text-gray-400">
-          {video.channelAvatar && (
-            <img
-              src={video.channelAvatar}
-              alt={`${video.channel} avatar`}
-              className="w-6 h-6 rounded-full mr-2 row-span-2"
-            />
-          )}
-          <div className="col-start-2">{video.channel}</div>
-          <div className="col-span-2 flex items-center gap-1 mt-1">
-            <span className="flex items-center gap-1">
-              <Eye className="w-3.5 h-3.5" />
-              {formatNumber(video.views)}
-            </span>
-            <span className="mx-1">•</span>
+        <div className="text-[13px] text-youtube-gray-dark dark:text-gray-400">
+            <div className="flex items-center gap-2 mb-1">
+              {video.channelAvatar && (
+                <img
+                  src={video.channelAvatar}
+                  alt={`${video.channel} avatar`}
+                  className="w-6 h-6 rounded-full"
+                />
+              )}
+              <span>{video.channel}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="flex items-center gap-1">
+                <Eye className="w-3.5 h-3.5" />
+                {formatNumber(video.views)}
+              </span>
+              <span className="mx-1">•</span>
             <span>{formatPublishDate(video.publishedAt)}</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- center channel avatar alongside the channel name
- keep views and publish date on their own line beneath

## Testing
- `cd bolt-app && npm test`
- `cd bolt-app && npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b17d151e088320a82e4f79d30616bf