### PR TITLE
chore: add typescript eslint dependency

### DIFF
--- a/bolt-app/package.json
+++ b/bolt-app/package.json
@@ -28,6 +28,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
+    "typescript-eslint": "^8.0.0",
     "vite": "^5.4.2",
     "globals": "^14.0.0"
   }


### PR DESCRIPTION
## Summary
- add typescript-eslint to dev dependencies so linting config has required package

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1935542588320a75da12f01ddf9d2