### PR TITLE
feat: sync theme with system preference

### DIFF
--- a/bolt-app/src/hooks/useTheme.ts
+++ b/bolt-app/src/hooks/useTheme.ts
@@ -24,6 +24,15 @@ export function useTheme() {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
   const toggleTheme = useCallback(() => {
     setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
   }, []);


### PR DESCRIPTION
## Summary
- listen for system color scheme changes and update theme accordingly

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1cbb644408320b005de90b4595b65