### PR TITLE
docs: close code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ Installation locale :
 ```bash
 python -m pip install --upgrade pip
 pip install -r requirements.txt
+```


### PR DESCRIPTION
## Summary
- fix missing closing code fence in README installation instructions

## Testing
- `python -m markdown README.md` *(fails: No module named markdown)*
- `pip install markdown` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cdf879708320a77ea118e456ec11