### PR TITLE
Handle invalid dates in format_published_at

### DIFF
--- a/main.py
+++ b/main.py
@@ -160,7 +160,10 @@ def get_thumbnail_url(video_data):
 
 def format_published_at(iso_timestamp):
     """Formate la date de publication ISO en 'dd/mm/YYYY HH:MM' (préfixée d'une apostrophe)."""
-    dt = datetime.strptime(iso_timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    try:
+        dt = datetime.strptime(iso_timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return ""
     return f"'{dt.strftime('%d/%m/%Y %H:%M')}"
 
 # Cache d’avatars de chaîne (évite de refaire des requêtes)

--- a/tests/test_published_at.py
+++ b/tests/test_published_at.py
@@ -9,3 +9,8 @@ from main import format_published_at
 def test_format_published_at_includes_time_and_prefix():
     iso = "2025-01-07T13:45:00Z"
     assert format_published_at(iso) == "'07/01/2025 13:45"
+
+
+def test_format_published_at_invalid_returns_empty_string():
+    invalid_iso = "not-a-date"
+    assert format_published_at(invalid_iso) == ""


### PR DESCRIPTION
## Summary
- handle ValueError in `format_published_at` and return an empty string on failure
- add test for invalid published date formatting

## Testing
- `python -m flake8` *(fails: No module named flake8)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `python -m py_compile main.py tests/test_published_at.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1ce01a25c8320ac0cf60287f7a961