### PR TITLE
Use video link as VideoCard key

### DIFF
--- a/bolt-app/src/components/VideoGrid.tsx
+++ b/bolt-app/src/components/VideoGrid.tsx
@@ -9,8 +9,8 @@ interface VideoGridProps {
 export function VideoGrid({ videos }: VideoGridProps) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-x-4 gap-y-8">
-      {videos.map((video, index) => (
-        <VideoCard key={index} video={video} />
+      {videos.map((video) => (
+        <VideoCard key={video.link} video={video} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- use each video's link as the key when rendering VideoCard components

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1d092ab1c8320936a1507002a7987