### PR TITLE
Map all sheet columns in mapRowToVideo

### DIFF
--- a/bolt-app/src/utils/api/sheets.ts
+++ b/bolt-app/src/utils/api/sheets.ts
@@ -45,7 +45,7 @@ function validateVideoData(row: any[]): boolean {
 
 function mapRowToVideo(row: any[]): VideoData {
   return {
-    thumbnail: String(row[12] || ''),
+    channelAvatar: String(row[0] || ''),
     title: String(row[1] || ''),
     link: String(row[2] || ''),
     channel: String(row[3] || ''),
@@ -54,12 +54,12 @@ function mapRowToVideo(row: any[]): VideoData {
     views: String(row[6] || '0'),
     likes: String(row[7] || '0'),
     comments: String(row[8] || '0'),
-        channelAvatar: String(row[0] || '')
-     };
-  
- 
-   
-  }
+    shortDescription: String(row[9] || ''),
+    tags: String(row[10] || ''),
+    category: String(row[11] || ''),
+    thumbnail: String(row[12] || '')
+  };
+}
   
 
 export async function fetchAllVideos(): Promise<VideoResponse> {


### PR DESCRIPTION
## Summary
- mapRowToVideo now maps every sheet column from channelAvatar to thumbnail in order.

## Testing
- `npm test`
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d08dbd5883208e9b7df0af9da4e4