### PR TITLE
feat: validate Google Sheets config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Secrets GitHub à créer :
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
-Variables d’environnement pour l’application web `bolt-app` :
-- `VITE_SPREADSHEET_ID`
-- `VITE_API_KEY`
+Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
+- `VITE_SPREADSHEET_ID` — identifiant de la feuille Google Sheets
+- `VITE_API_KEY` — clé API Google Sheets
 
-Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées.
+Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées. L’application
+échouera au démarrage si l’une de ces variables est absente.
 
 ## Dépendances
 

--- a/bolt-app/.env.example
+++ b/bolt-app/.env.example
@@ -1,2 +1,5 @@
-VITE_SPREADSHEET_ID=
-VITE_API_KEY=
+# Obligatoire : identifiant du Google Sheet
+VITE_SPREADSHEET_ID=your-spreadsheet-id
+
+# Obligatoire : clé API Google Sheets
+VITE_API_KEY=your-api-key

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -16,3 +16,7 @@ const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 
 export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? '';
 export const API_KEY = env.VITE_API_KEY ?? '';
+
+if (!SPREADSHEET_ID || !API_KEY) {
+  throw new Error('Google Sheets API key or spreadsheet ID not configured');
+}


### PR DESCRIPTION
## Summary
- throw early error if Google Sheets API key or spreadsheet ID are missing
- document required `VITE_SPREADSHEET_ID` and `VITE_API_KEY`

## Testing
- `npm run lint`
- `VITE_SPREADSHEET_ID=dummy VITE_API_KEY=dummy npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d2a96a9483209fa859e3bf3ac349