### PR TITLE
feat: surface partial sheet errors

### DIFF
--- a/bolt-app/src/hooks/useVideos.ts
+++ b/bolt-app/src/hooks/useVideos.ts
@@ -11,20 +11,23 @@ export function useVideos() {
     try {
       setIsLoading(true);
       setError(null);
-      
+
       const { data, error: apiError, metadata } = await fetchAllVideos();
-      
+
       if (apiError) {
-        const errorMessage = metadata?.errors?.length 
+        const errorMessage = metadata?.errors?.length
           ? metadata.errors.join('\n')
           : apiError;
         setError(errorMessage);
         setVideos([]);
       } else {
-        if (data.length === 0) {
+        setVideos(data);
+
+        if (metadata?.errors?.length) {
+          setError(metadata.errors.join('\n'));
+        } else if (data.length === 0) {
           setError('Aucune vidéo trouvée.');
         } else {
-          setVideos(data);
           setError(null);
         }
       }


### PR DESCRIPTION
## Summary
- include metadata.errors when some sheet tabs fail
- show partial fetch errors in useVideos hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d2af6c7c8320b7004947faf0652d