### PR TITLE
Add ErrorBoundary component to app

### DIFF
--- a/bolt-app/src/components/ErrorBoundary.tsx
+++ b/bolt-app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo);
+    this.setState({ hasError: true });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center p-8 text-center">
+          <p className="mb-4 text-red-600">Something went wrong.</p>
+          <button
+            className="rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/bolt-app/src/main.tsx
+++ b/bolt-app/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import ErrorBoundary from './components/ErrorBoundary';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add React ErrorBoundary component with reload button
- wrap application root with ErrorBoundary to catch rendering errors

## Testing
- `npm --prefix bolt-app test` *(fails: Google Sheets API key or spreadsheet ID not configured)*
- `npm --prefix bolt-app run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d4872ed883208dc8d1c2c81cbaa9