### PR TITLE
feat: handle missing configuration

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -8,7 +8,8 @@ import { LoadingState } from './components/LoadingState';
 import { ErrorState } from './components/ErrorState';
 import { SoundToggle } from './components/ui/SoundToggle';
 import { ThemeToggle } from './components/ui/ThemeToggle';
-import { SHEET_TABS } from './utils/constants';
+import { SHEET_TABS, getConfig } from './utils/constants';
+import { MissingConfig } from './components/MissingConfig';
 import { filterVideosByDuration } from './utils/videoFilters';
 import { filterVideosBySearch } from './utils/searchUtils';
 import { sortVideos } from './utils/sortUtils';
@@ -18,6 +19,9 @@ import { SearchFilters } from './types/search';
 import { SortOptions } from './types/sort';
 
 export default function App() {
+  const { SPREADSHEET_ID, API_KEY } = getConfig();
+  const hasValidConfig = Boolean(SPREADSHEET_ID && API_KEY);
+
   const { videos, isLoading, error, loadVideos } = useVideos();
   const { playClick } = useSound();
   const [selectedTab, setSelectedTab] = React.useState(-1);
@@ -37,12 +41,16 @@ export default function App() {
       query: '',
       fields: ['title', 'channel', 'category']
     });
-    await loadVideos();
-  }, [loadVideos, playClick]);
+    if (hasValidConfig) {
+      await loadVideos();
+    }
+  }, [loadVideos, playClick, hasValidConfig]);
 
   React.useEffect(() => {
-    loadVideos();
-  }, [loadVideos]);
+    if (hasValidConfig) {
+      loadVideos();
+    }
+  }, [loadVideos, hasValidConfig]);
 
   // Filtrage par recherche
   const filteredBySearch = React.useMemo(() =>
@@ -63,6 +71,10 @@ export default function App() {
     () => sortVideos(filteredByDuration, sortOptions),
     [filteredByDuration, sortOptions]
   );
+
+  if (!hasValidConfig) {
+    return <MissingConfig />;
+  }
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden">

--- a/bolt-app/src/components/MissingConfig.tsx
+++ b/bolt-app/src/components/MissingConfig.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+export function MissingConfig() {
+  return (
+    <div className="flex items-center justify-center p-8">
+      <div className="bg-red-50 text-red-500 p-4 rounded-lg flex items-center">
+        <AlertTriangle className="w-5 h-5 mr-2" />
+        <p>Google Sheets API key or spreadsheet ID not configured.</p>
+      </div>
+    </div>
+  );
+}

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -17,6 +17,10 @@ const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? '';
 export const API_KEY = env.VITE_API_KEY ?? '';
 
-if (!SPREADSHEET_ID || !API_KEY) {
-  throw new Error('Google Sheets API key or spreadsheet ID not configured');
+export function getConfig() {
+  if (!SPREADSHEET_ID || !API_KEY) {
+    console.error('Google Sheets API key or spreadsheet ID not configured');
+    return { SPREADSHEET_ID: '', API_KEY: '' };
+  }
+  return { SPREADSHEET_ID, API_KEY };
 }


### PR DESCRIPTION
## Summary
- avoid throwing when env config is missing
- show explicit error screen when API key or spreadsheet id are absent

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d485189c8320823db2a52fe61497