### PR TITLE
Support non-Vite env vars in config constants

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -14,8 +14,10 @@ export const SHEET_TABS: SheetTab[] = [
 
 const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 
-export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? '';
-export const API_KEY = env.VITE_API_KEY ?? '';
+export const SPREADSHEET_ID =
+  env.VITE_SPREADSHEET_ID ?? env.SPREADSHEET_ID ?? '';
+export const API_KEY =
+  env.VITE_API_KEY ?? env.API_KEY ?? '';
 
 export function getConfig() {
   if (!SPREADSHEET_ID || !API_KEY) {


### PR DESCRIPTION
## Summary
- allow `SPREADSHEET_ID` and `API_KEY` to read non-Vite env vars

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6a3267c8320bd670439634ddfd0