### PR TITLE
refactor: use prefixed env vars for sheet config

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -14,10 +14,8 @@ export const SHEET_TABS: SheetTab[] = [
 
 const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 
-export const SPREADSHEET_ID =
-  env.VITE_SPREADSHEET_ID ?? env.SPREADSHEET_ID ?? '';
-export const API_KEY =
-  env.VITE_API_KEY ?? env.API_KEY ?? '';
+export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? '';
+export const API_KEY = env.VITE_API_KEY ?? '';
 
 export function getConfig() {
   if (!SPREADSHEET_ID || !API_KEY) {


### PR DESCRIPTION
## Summary
- remove fallback to unprefixed env vars when extracting API and spreadsheet configuration

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1dd418694832094bf1834f2627afa