### PR TITLE
Align video data schema with sheet structure

### DIFF
--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -1,5 +1,5 @@
 export interface VideoData {
-  thumbnail: string;      // Colonne A
+  channelAvatar: string;  // Colonne A
   title: string;          // Colonne B
   link: string;           // Colonne C
   channel: string;        // Colonne D
@@ -11,7 +11,7 @@ export interface VideoData {
   shortDescription: string; // Colonne J
   tags: string;           // Colonne K
   category: string;       // Colonne L
-  channelAvatar: string;  // Colonne M
+  thumbnail: string;      // Colonne M
 }
 
 export interface VideoResponse {

--- a/bolt-app/src/utils/api/sheets.ts
+++ b/bolt-app/src/utils/api/sheets.ts
@@ -36,6 +36,8 @@ async function fetchSheetData(range: string): Promise<any[]> {
 function validateVideoData(row: any[]): boolean {
   return (
     Array.isArray(row) &&
+    row.length >= 13 &&
+    typeof row[0] === 'string' && // Avatar de la chaîne
     typeof row[1] === 'string' && // Titre
     typeof row[2] === 'string' && // Lien
     row[1].trim() !== '' &&


### PR DESCRIPTION
## Summary
- Ensure `VideoData` fields correspond to sheet columns and document their order.
- Validate that Google Sheets rows contain all expected columns before mapping.
- Confirm fallback loading of `public/data/videos.json` when API credentials are absent.

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1f651f9548320b4988d54cce9e007