### PR TITLE
Fix Google Sheet tab creation in sync script

### DIFF
--- a/main.py
+++ b/main.py
@@ -314,7 +314,8 @@ def sync_videos():
     # en créant l’onglet s’il n’existe pas et en remplaçant les valeurs existantes.
     # Cette logique peut rester inchangée par rapport à votre implémentation actuelle.
     # Exemple succinct :
-sheet_name = os.environ.get("SHEET_TAB_NAME", "AllVideos")
+    sheet_name = os.environ.get("SHEET_TAB_NAME", "AllVideos")
+    sheet_id = get_sheet_id(SPREADSHEET_ID, sheet_name, service)
     if sheet_id is None:
         # Ajout d’une nouvelle feuille
         requests_body = {


### PR DESCRIPTION
## Summary
- restore missing sheet ID retrieval and creation block indentation
- create sheet tab when missing before writing playlist data

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b22706b708832098753eeb5fd7966b