### PR TITLE
Handle local video fetch failures

### DIFF
--- a/bolt-app/src/hooks/useVideos.ts
+++ b/bolt-app/src/hooks/useVideos.ts
@@ -14,22 +14,18 @@ export function useVideos() {
 
       const { data, error: apiError, metadata } = await fetchAllVideos();
 
-      if (apiError) {
-        const errorMessage = metadata?.errors?.length
-          ? metadata.errors.join('\n')
-          : apiError;
-        setError(errorMessage);
-        setVideos([]);
-      } else {
-        setVideos(data);
+      const errorMessage = apiError || (metadata?.errors?.length
+        ? metadata.errors.join('\n')
+        : null);
 
-        if (metadata?.errors?.length) {
-          setError(metadata.errors.join('\n'));
-        } else if (data.length === 0) {
-          setError('Aucune vidéo trouvée.');
-        } else {
-          setError(null);
-        }
+      setVideos(errorMessage ? [] : data);
+
+      if (errorMessage) {
+        setError(errorMessage);
+      } else if (data.length === 0) {
+        setError('Aucune vidéo trouvée.');
+      } else {
+        setError(null);
       }
     } catch (err) {
       setError('Une erreur inattendue est survenue. Veuillez réessayer.');

--- a/bolt-app/src/utils/api/sheets.ts
+++ b/bolt-app/src/utils/api/sheets.ts
@@ -76,7 +76,12 @@ export async function fetchAllVideos(): Promise<VideoResponse> {
       return { data: videos };
     } catch (err) {
       console.error('Erreur lors du chargement des vidéos locales:', err);
-      return { data: [] };
+      return {
+        data: [],
+        error: err instanceof Error
+          ? err.message
+          : 'Erreur lors du chargement des vidéos locales'
+      };
     }
   }
   const errors: string[] = [];


### PR DESCRIPTION
## Summary
- Return error message when local `videos.json` fetch fails
- Surface API error messages in `useVideos` instead of generic message

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b22e563eec8320a84c75920c4a119a