### PR TITLE
Validate config and fall back to local videos

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -6,6 +6,7 @@ import { SearchBar } from './components/SearchBar';
 import { SortSelect } from './components/SortSelect';
 import { LoadingState } from './components/LoadingState';
 import { ErrorState } from './components/ErrorState';
+import { MissingConfig } from './components/MissingConfig';
 import { SoundToggle } from './components/ui/SoundToggle';
 import { ThemeToggle } from './components/ui/ThemeToggle';
 import { SHEET_TABS, getConfig } from './utils/constants';
@@ -20,7 +21,7 @@ import { SortOptions } from './types/sort';
 export default function App() {
   const { error: configError } = getConfig();
 
-  const { videos, isLoading, error: videosError, loadVideos } = useVideos();
+  const { videos, isLoading, error: videosError, loadVideos } = useVideos(configError);
   const { playClick } = useSound();
   const [selectedTab, setSelectedTab] = React.useState(-1);
   const [sortOptions, setSortOptions] = React.useState<SortOptions>({
@@ -65,7 +66,7 @@ export default function App() {
     [filteredByDuration, sortOptions]
   );
 
-  const appError = videosError || configError;
+  const appError = videosError;
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden">
@@ -114,6 +115,7 @@ export default function App() {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+        {configError && <MissingConfig message={configError} />}
         {!isLoading && !appError && (
           <>
             <SearchBar

--- a/bolt-app/src/components/MissingConfig.tsx
+++ b/bolt-app/src/components/MissingConfig.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { AlertTriangle } from 'lucide-react';
 
-export function MissingConfig() {
+export function MissingConfig({ message }: { message?: string }) {
   return (
     <div className="flex items-center justify-center p-8">
       <div className="bg-red-50 text-red-500 p-4 rounded-lg flex items-center">
         <AlertTriangle className="w-5 h-5 mr-2" />
-        <p>Google Sheets API key or spreadsheet ID not configured.</p>
+        <p>{message ?? 'Google Sheets API key or spreadsheet ID not configured.'}</p>
       </div>
     </div>
   );

--- a/bolt-app/src/hooks/useVideos.ts
+++ b/bolt-app/src/hooks/useVideos.ts
@@ -1,8 +1,8 @@
 import { useState, useCallback } from 'react';
 import { VideoData } from '../types/video';
-import { fetchAllVideos } from '../utils/api/sheets';
+import { fetchAllVideos, fetchLocalVideos } from '../utils/api/sheets';
 
-export function useVideos() {
+export function useVideos(configError?: string) {
   const [videos, setVideos] = useState<VideoData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -11,8 +11,9 @@ export function useVideos() {
     try {
       setIsLoading(true);
       setError(null);
-
-      const { data, error: apiError, metadata } = await fetchAllVideos();
+      const { data, error: apiError, metadata } = configError
+        ? await fetchLocalVideos()
+        : await fetchAllVideos();
 
       const errorMessage = apiError || (metadata?.errors?.length
         ? metadata.errors.join('\n')
@@ -33,7 +34,7 @@ export function useVideos() {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [configError]);
 
   return {
     videos,

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -18,13 +18,22 @@ export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? env.SPREADSHEET_ID ?? e
 export const API_KEY = env.VITE_API_KEY ?? env.API_KEY ?? env.REACT_APP_API_KEY ?? '';
 
 
+export function isValidSpreadsheetId(id: string): boolean {
+  return /^[A-Za-z0-9-_]{40,60}$/.test(id);
+}
+
 export function getConfig(): {
   SPREADSHEET_ID: string;
   API_KEY: string;
   error?: string;
 } {
-  if (!SPREADSHEET_ID || !API_KEY) {
-    const error = 'Google Sheets API key or spreadsheet ID not configured';
+  if (!isValidSpreadsheetId(SPREADSHEET_ID)) {
+    const error = 'SPREADSHEET_ID invalide';
+    console.error(error);
+    return { SPREADSHEET_ID: '', API_KEY: '', error };
+  }
+  if (!API_KEY) {
+    const error = 'API_KEY manquant';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }


### PR DESCRIPTION
## Summary
- validate spreadsheet ID format and surface config errors
- load local videos when config is invalid and show MissingConfig message
- expose utility to fetch fallback data from `/data/videos.json`

## Testing
- `npm --prefix bolt-app test`
- `npm --prefix bolt-app run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23030aa9c8320a70b99dcfa395ac8