### PR TITLE
Handle full Google Sheet URLs for SPREADSHEET_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Tu peux toujours déclencher manuellement via l’onglet **Actions**.
 
 Secrets GitHub à créer :
 - `YOUTUBE_API_KEY`
-- `SPREADSHEET_ID`
+- `SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
-- `VITE_SPREADSHEET_ID` — identifiant de la feuille Google Sheets
+- `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
 - `VITE_API_KEY` — clé API Google Sheets
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées. L’application

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -14,12 +14,18 @@ export const SHEET_TABS: SheetTab[] = [
 
 const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 
-export const SPREADSHEET_ID = env.VITE_SPREADSHEET_ID ?? env.SPREADSHEET_ID ?? env.REACT_APP_SPREADSHEET_ID ?? '';
+export function parseSpreadsheetId(input: string): string {
+  const match = input?.match(/\/spreadsheets\/d\/([A-Za-z0-9-_]{25,60})/);
+  return match ? match[1] : (input ?? '').trim();
+}
+
+const rawSpreadsheetId =
+  env.VITE_SPREADSHEET_ID ?? env.SPREADSHEET_ID ?? env.REACT_APP_SPREADSHEET_ID ?? '';
+export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 export const API_KEY = env.VITE_API_KEY ?? env.API_KEY ?? env.REACT_APP_API_KEY ?? '';
 
-
 export function isValidSpreadsheetId(id: string): boolean {
-  return /^[A-Za-z0-9-_]{40,60}$/.test(id);
+  return /^[A-Za-z0-9-_]{25,60}$/.test(id);
 }
 
 export function getConfig(): {

--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import csv
 import pathlib
@@ -21,7 +22,16 @@ def parse_ranges(raw: str) -> List[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
-SPREADSHEET_ID = os.environ["SPREADSHEET_ID"]
+def parse_spreadsheet_id(value: str) -> str:
+    match = re.search(r"/spreadsheets/d/([A-Za-z0-9-_]{25,60})", value or "")
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[A-Za-z0-9-_]{25,60}", value or ""):
+        return value.strip()
+    raise ValueError("SPREADSHEET_ID invalide")
+
+
+SPREADSHEET_ID = parse_spreadsheet_id(os.environ["SPREADSHEET_ID"])
 SHEET_RANGES = parse_ranges(os.environ.get("SHEET_RANGE", "AllVideos!A1:Z"))
 for sheet_range in SHEET_RANGES:
     if "!" not in sheet_range:


### PR DESCRIPTION
## Summary
- Allow spreadsheet URL parsing on both frontend and scripts
- Validate and extract spreadsheet IDs in Python utilities
- Document that spreadsheet environment variables accept full URLs

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b231f4e20883208fe8ba50c34620dc