### PR TITLE
Improve spreadsheet ID validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ Tu peux toujours déclencher manuellement via l’onglet **Actions**.
 Secrets GitHub à créer :
 - `YOUTUBE_API_KEY`
 - `SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
+  (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
+  (25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `VITE_API_KEY` — clé API Google Sheets
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées. L’application

--- a/bolt-app/src/utils/constants.test.ts
+++ b/bolt-app/src/utils/constants.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSpreadsheetId, isValidSpreadsheetId } from './constants.ts';
+
+test('parseSpreadsheetId extracts id from full URL', () => {
+  const id = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7Q8R9S0T1U2V3W4X5Y6Z7_';
+  const url = `https://docs.google.com/spreadsheets/d/${id}/edit#gid=0`;
+  assert.equal(parseSpreadsheetId(url), id);
+});
+
+test('isValidSpreadsheetId enforces length and characters', () => {
+  const valid = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7Q8R9S0T1U2V3W4X5Y6Z7_';
+  assert.ok(isValidSpreadsheetId(valid));
+  assert.equal(isValidSpreadsheetId('short'), false);
+});

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -19,7 +19,7 @@ const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
  * On applique toujours trim() pour éliminer les espaces ou retours à la ligne.
  */
 export function parseSpreadsheetId(input: string): string {
-  const match = input?.match(/\/spreadsheets\/d\/([A-Za-z0-9-_]+)/);
+  const match = input?.match(/\/spreadsheets\/d\/([A-Za-z0-9-_]{25,60})/);
   const id = match ? match[1] : (input ?? '');
   return id.trim();
 }
@@ -39,7 +39,7 @@ export const API_KEY =
  * des lettres, chiffres, tirets ou soulignés.
  */
 export function isValidSpreadsheetId(id: string): boolean {
-  return id.length > 0 && /^[A-Za-z0-9-_]+$/.test(id);
+  return /^[A-Za-z0-9-_]{25,60}$/.test(id);
 }
 
 export function getConfig(): {
@@ -49,7 +49,7 @@ export function getConfig(): {
 } {
   // Si l’ID est vide, on considère qu’il est manquant et on affiche le message approprié.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant';
+    const error = 'SPREADSHEET_ID manquant : définissez VITE_SPREADSHEET_ID';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }


### PR DESCRIPTION
## Summary
- validate spreadsheet IDs using expected Google pattern
- clarify configuration in documentation
- add tests for spreadsheet ID parsing

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1a2672883208cd0a835f1375d9d