### PR TITLE
Allow sheet config via URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,20 @@ Tu peux toujours déclencher manuellement via l’onglet **Actions**.
 Secrets GitHub à créer :
 - `YOUTUBE_API_KEY`
 - `SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
+  (une suite de 25 à 90 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
+  (25 à 90 caractères alphanumériques, tirets ou soulignés)
 - `VITE_API_KEY` — clé API Google Sheets
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées. L’application
-échouera au démarrage si l’une de ces variables est absente.
+échouera au démarrage si l’une de ces variables est absente. À défaut, tu peux
+aussi fournir les paramètres `spreadsheetId` et `apiKey` via l’URL, par exemple :
+`http://localhost:5173/?spreadsheetId=ID&apiKey=KEY`.
 
 ## Dépendances
 

--- a/bolt-app/src/utils/constants.test.ts
+++ b/bolt-app/src/utils/constants.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSpreadsheetId, isValidSpreadsheetId, buildConfig } from './constants.ts';
+
+test('parseSpreadsheetId extracts id from full URL', () => {
+  const id = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7Q8R9S0T1U2V3W4X5Y6Z7_';
+  const url = `https://docs.google.com/spreadsheets/d/${id}/edit#gid=0`;
+  assert.equal(parseSpreadsheetId(url), id);
+});
+
+test('isValidSpreadsheetId enforces length and characters', () => {
+  const valid = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7Q8R9S0T1U2V3W4X5Y6Z7_';
+  assert.ok(isValidSpreadsheetId(valid));
+  assert.equal(isValidSpreadsheetId('short'), false);
+});
+
+test('buildConfig falls back to URL parameters', () => {
+  const id = '1A2B3C4D5E6F7G8H9I0J1K2L3M4N5O6P7Q8R9S0T1U2V3W4X5Y6Z7_';
+  const key = 'test-key';
+  const cfg = buildConfig({}, `?spreadsheetId=${id}&apiKey=${key}`);
+  assert.equal(cfg.SPREADSHEET_ID, id);
+  assert.equal(cfg.API_KEY, key);
+  assert.equal(cfg.error, undefined);
+});

--- a/main.py
+++ b/main.py
@@ -28,13 +28,13 @@ HEADERS = [
 DEFAULT_AVATAR_URL = "https://via.placeholder.com/48"
 DEFAULT_THUMBNAIL_URL = "https://via.placeholder.com/480x360?text=No+Thumbnail"
 
-_SPREADSHEET_RE = re.compile(r"/spreadsheets/d/([A-Za-z0-9-_]{25,60})")
+_SPREADSHEET_RE = re.compile(r"/spreadsheets/d/([A-Za-z0-9-_]{25,90})")
 
 def parse_spreadsheet_id(value: str) -> str | None:
     match = _SPREADSHEET_RE.search(value or "")
     if match:
         return match.group(1)
-    if re.fullmatch(r"[A-Za-z0-9-_]{25,60}", value or ""):
+    if re.fullmatch(r"[A-Za-z0-9-_]{25,90}", value or ""):
         return value.strip()
     return None
 

--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -23,10 +23,10 @@ def parse_ranges(raw: str) -> List[str]:
 
 
 def parse_spreadsheet_id(value: str) -> str:
-    match = re.search(r"/spreadsheets/d/([A-Za-z0-9-_]{25,60})", value or "")
+    match = re.search(r"/spreadsheets/d/([A-Za-z0-9-_]{25,90})", value or "")
     if match:
         return match.group(1)
-    if re.fullmatch(r"[A-Za-z0-9-_]{25,60}", value or ""):
+    if re.fullmatch(r"[A-Za-z0-9-_]{25,90}", value or ""):
         return value.strip()
     raise ValueError("SPREADSHEET_ID invalide")
 


### PR DESCRIPTION
## Summary
- read sheet ID and API key from URL when env vars missing
- broaden spreadsheet ID validation to 90 chars and sync Python tools
- document URL fallback and add test for config resolution

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1a2672883208cd0a835f1375d9d