### PR TITLE
docs: clarify web env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Obligatoire : identifiant du Google Sheet
+VITE_SPREADSHEET_ID=your-spreadsheet-id
+
+# Obligatoire : clé API Google Sheets
+VITE_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -41,8 +41,15 @@ Variables d’environnement **obligatoires** pour l’application web `bolt-app`
   (25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `VITE_API_KEY` — clé API Google Sheets
 
-Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées. L’application
-échouera au démarrage si l’une de ces variables est absente.
+Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées (un modèle
+est fourni dans `.env.example`). L’application échouera au démarrage si l’une de
+ces variables est absente.
+
+Seules les variables préfixées par `VITE_` sont exposées côté client ; des noms
+comme `SPREADSHEET_ID` ou `API_KEY` ne seront pas accessibles.
+
+Pour des tests rapides, ces valeurs peuvent aussi être fournies via l’URL :
+`?spreadsheetId=` et `?apiKey=`.
 
 ## Dépendances
 


### PR DESCRIPTION
## Summary
- document required Vite environment variables for web app
- add example `.env.example`
- note URL query parameters for quick tests

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b2cd80d1d0832082ea22fcf2db14b0