### PR TITLE
Validate sheet config before API calls

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -1,10 +1,14 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchSheetData } from './fetch.ts';
 
 // Verify that fetchSheetData correctly handles ranges without an upper bound
 // and returns all available rows.
 test('fetchSheetData retrieves all rows for unbounded range', async () => {
+  process.env.VITE_SPREADSHEET_ID = '1234567890123456789012345';
+  process.env.VITE_API_KEY = 'test_key';
+
+  const { fetchSheetData } = await import('./fetch.ts');
+
   const rows = Array.from({ length: 1201 }, () => ['value']);
 
   mock.method(globalThis as any, 'fetch', async (input: any) => {

--- a/bolt-app/src/utils/api/sheets/fetch.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.ts
@@ -1,5 +1,5 @@
 import type { SheetResponse } from './types.ts';
-import { SPREADSHEET_ID, API_KEY } from '../../constants.ts';
+import { getConfig } from '../../constants.ts';
 
 const RATE_LIMIT = {
   requests: 0,
@@ -76,6 +76,11 @@ async function fetchWithRetry(url: string, retryCount = 0): Promise<Response> {
 export async function fetchSheetData(range: string): Promise<SheetResponse> {
   try {
     checkRateLimit();
+
+    const { SPREADSHEET_ID, API_KEY, error } = getConfig();
+    if (error) {
+      return { error, values: [] };
+    }
 
     // Properly encode the range parameter
     const encodedRange = encodeURIComponent(range);

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -1,11 +1,15 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { synchronizeSheets } from './sync.ts';
-import { SHEET_TABS } from '../../constants.ts';
 
 // Ensure the sheet synchronization can handle more than 1000 rows
 // by mocking the global fetch to return 1201 unique entries.
 test('synchronizeSheets handles large sheet ranges', async () => {
+  process.env.VITE_SPREADSHEET_ID = '1234567890123456789012345';
+  process.env.VITE_API_KEY = 'test_key';
+
+  const { synchronizeSheets } = await import('./sync.ts');
+  const { SHEET_TABS } = await import('../../constants.ts');
+
   const rows = Array.from({ length: 1201 }, (_, i) => [
     'https://example.com/avatar.jpg',
     `Title ${i}`,


### PR DESCRIPTION
## Summary
- load Sheets API credentials via `getConfig`
- abort video fetch if spreadsheet config is invalid
- verify sheet config before building fetch URLs

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2cd7de72083209b737202e15a5556