### PR TITLE
test: restore env vars in sheet tests

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -1,20 +1,38 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchSheetData } from './fetch.ts';
 
 // Verify that fetchSheetData correctly handles ranges without an upper bound
 // and returns all available rows.
 test('fetchSheetData retrieves all rows for unbounded range', async () => {
   const rows = Array.from({ length: 1201 }, () => ['value']);
 
-  mock.method(globalThis as any, 'fetch', async (input: any) => {
-    const url = typeof input === 'string' ? input : input.url;
-    assert.ok(url.includes(encodeURIComponent('tab!A2:M')));
-    return new Response(JSON.stringify({ values: rows }), { status: 200 });
-  });
+  const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
+  const originalApiKey = process.env.VITE_API_KEY;
+  process.env.VITE_SPREADSHEET_ID = 'test-id';
+  process.env.VITE_API_KEY = 'test-key';
 
-  const result = await fetchSheetData('tab!A2:M');
-  assert.equal(result.values.length, 1201);
+  try {
+    const { fetchSheetData } = await import('./fetch.ts');
 
-  mock.restoreAll();
+    mock.method(globalThis as any, 'fetch', async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      assert.ok(url.includes(encodeURIComponent('tab!A2:M')));
+      return new Response(JSON.stringify({ values: rows }), { status: 200 });
+    });
+
+    const result = await fetchSheetData('tab!A2:M');
+    assert.equal(result.values.length, 1201);
+  } finally {
+    mock.restoreAll();
+    if (originalSpreadsheetId === undefined) {
+      delete process.env.VITE_SPREADSHEET_ID;
+    } else {
+      process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.VITE_API_KEY;
+    } else {
+      process.env.VITE_API_KEY = originalApiKey;
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- ensure sheet tests save and restore VITE_SPREADSHEET_ID and VITE_API_KEY for isolation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d031582c8320a383030217ce3fc4