### PR TITLE
refactor: inject sheet config

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -1,6 +1,6 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchSheetData } from './fetch.ts';
+import { fetchSheetData, type SheetsConfig } from './fetch.ts';
 
 // Verify that fetchSheetData correctly handles ranges without an upper bound
 // and returns all available rows.
@@ -13,7 +13,8 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
     return new Response(JSON.stringify({ values: rows }), { status: 200 });
   });
 
-  const result = await fetchSheetData('tab!A2:M');
+  const config: SheetsConfig = { SPREADSHEET_ID: 'spreadsheet', API_KEY: 'key' };
+  const result = await fetchSheetData('tab!A2:M', config);
   assert.equal(result.values.length, 1201);
 
   mock.restoreAll();

--- a/bolt-app/src/utils/api/sheets/fetch.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.ts
@@ -1,5 +1,9 @@
 import type { SheetResponse } from './types.ts';
-import { SPREADSHEET_ID, API_KEY } from '../../constants.ts';
+
+export interface SheetsConfig {
+  SPREADSHEET_ID: string;
+  API_KEY: string;
+}
 
 const RATE_LIMIT = {
   requests: 0,
@@ -73,13 +77,16 @@ async function fetchWithRetry(url: string, retryCount = 0): Promise<Response> {
   }
 }
 
-export async function fetchSheetData(range: string): Promise<SheetResponse> {
+export async function fetchSheetData(
+  range: string,
+  config: SheetsConfig
+): Promise<SheetResponse> {
   try {
     checkRateLimit();
 
     // Properly encode the range parameter
     const encodedRange = encodeURIComponent(range);
-    const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values/${encodedRange}?key=${API_KEY}`;
+    const url = `https://sheets.googleapis.com/v4/spreadsheets/${config.SPREADSHEET_ID}/values/${encodedRange}?key=${config.API_KEY}`;
     
     const response = await fetchWithRetry(url);
     const data = await response.json();

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -1,11 +1,13 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { synchronizeSheets } from './sync.ts';
-import { SHEET_TABS } from '../../constants.ts';
 
-// Ensure the sheet synchronization can handle more than 1000 rows
-// by mocking the global fetch to return 1201 unique entries.
 test('synchronizeSheets handles large sheet ranges', async () => {
+  process.env.VITE_SPREADSHEET_ID = '1'.repeat(25);
+  process.env.VITE_API_KEY = 'key';
+
+  const { synchronizeSheets } = await import('./sync.ts');
+  const { SHEET_TABS } = await import('../../constants.ts');
+
   const rows = Array.from({ length: 1201 }, (_, i) => [
     'https://example.com/avatar.jpg',
     `Title ${i}`,
@@ -35,3 +37,4 @@ test('synchronizeSheets handles large sheet ranges', async () => {
 
   mock.restoreAll();
 });
+

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -1,5 +1,5 @@
-import { fetchSheetData } from './fetch.ts';
-import { SHEET_TABS } from '../../constants.ts';
+import { fetchSheetData, type SheetsConfig } from './fetch.ts';
+import { SHEET_TABS, getConfig } from '../../constants.ts';
 import type { VideoData } from '../../../types/video.ts';
 import { validateRow } from './validation.ts';
 import { processVideoData } from '../../youtube.ts';
@@ -37,12 +37,17 @@ function validateAndFormatDate(rawDate: any, videoTitle: string): string {
 export async function synchronizeSheets(): Promise<VideoData[]> {
   try {
     console.log('Starting sheet synchronization...');
+    const { SPREADSHEET_ID, API_KEY, error } = getConfig();
+    if (error) {
+      throw new Error(error);
+    }
+    const config: SheetsConfig = { SPREADSHEET_ID, API_KEY };
     const videoMap: VideoMap = {};
     const errors: string[] = [];
 
     // Process all tabs in parallel for better performance
     const tabResults = await Promise.allSettled(
-      SHEET_TABS.map(tab => fetchSheetData(tab.range))
+      SHEET_TABS.map(tab => fetchSheetData(tab.range, config))
     );
 
     // Process results from each tab


### PR DESCRIPTION
## Summary
- allow passing Sheets API configuration to `fetchSheetData`
- read spreadsheet config once in `synchronizeSheets` and forward to fetch calls
- adjust tests to pass configuration

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2d033dea48320ae37a40e307240b3