### PR TITLE
fix: preserve YouTube ID case

### DIFF
--- a/bolt-app/src/utils/youtube.test.ts
+++ b/bolt-app/src/utils/youtube.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractYouTubeId, generateThumbnail } from './youtube.ts';
+
+test('extractYouTubeId preserves mixed-case video IDs', () => {
+  const url = 'https://YouTube.com/watch?v=aBcDeFgHiJk';
+  const id = extractYouTubeId(url);
+  assert.equal(id, 'aBcDeFgHiJk');
+});
+
+test('generateThumbnail returns valid URL for mixed-case IDs', () => {
+  const url = 'https://YoUtU.Be/aBcDeFgHiJk';
+  const thumbnail = generateThumbnail(url);
+  assert.equal(thumbnail, 'https://img.youtube.com/vi/aBcDeFgHiJk/hqdefault.jpg');
+});

--- a/bolt-app/src/utils/youtube.ts
+++ b/bolt-app/src/utils/youtube.ts
@@ -2,9 +2,9 @@ import type { VideoData } from '../types/video.ts';
 
 // Supported YouTube URL patterns
 const URL_PATTERNS = {
-  STANDARD: /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-  SHORTS: /youtube\.com\/shorts\/([^&\n?#]+)/,
-  PLAYLIST: /youtube\.com\/playlist\?list=([^&\n?#]+)/
+  STANDARD: /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/i,
+  SHORTS: /youtube\.com\/shorts\/([^&\n?#]+)/i,
+  PLAYLIST: /youtube\.com\/playlist\?list=([^&\n?#]+)/i
 };
 
 /**
@@ -12,8 +12,8 @@ const URL_PATTERNS = {
  */
 export function extractYouTubeId(url: string): string | null {
   try {
-    // Clean and normalize the URL
-    const cleanUrl = url.trim().toLowerCase();
+    // Clean the URL but preserve original case for video IDs
+    const cleanUrl = url.trim();
     
     // Try each pattern
     for (const [format, pattern] of Object.entries(URL_PATTERNS)) {

--- a/youtube.ts
+++ b/youtube.ts
@@ -4,9 +4,9 @@ import type { VideoData } from '../types/video.ts';
 // expressions régulières capturent l'identifiant de la vidéo ou de la playlist
 // afin de le réutiliser pour générer des miniatures fiables.
 const URL_PATTERNS = {
-  STANDARD: /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-  SHORTS: /youtube\.com\/shorts\/([^&\n?#]+)/,
-  PLAYLIST: /youtube\.com\/playlist\?list=([^&\n?#]+)/
+  STANDARD: /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/i,
+  SHORTS: /youtube\.com\/shorts\/([^&\n?#]+)/i,
+  PLAYLIST: /youtube\.com\/playlist\?list=([^&\n?#]+)/i
 };
 
 /**
@@ -17,7 +17,7 @@ const URL_PATTERNS = {
  */
 export function extractYouTubeId(url: string): string | null {
   try {
-    const cleanUrl = url.trim().toLowerCase();
+    const cleanUrl = url.trim();
     for (const [_key, pattern] of Object.entries(URL_PATTERNS)) {
       const match = cleanUrl.match(pattern);
       if (match && match[1]) {


### PR DESCRIPTION
## Summary
- keep original casing when extracting YouTube IDs
- cover mixed-case IDs in generateThumbnail tests

## Testing
- `npm run lint`
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebc7e3dc83208733fac6a1da4b31