### PR TITLE
Handle empty dates and support French date sorting

### DIFF
--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -3,6 +3,7 @@ import { SHEET_TABS } from '../../constants.ts';
 import type { VideoData } from '../../../types/video.ts';
 import { validateRow } from './validation.ts';
 import { processVideoData } from '../../youtube.ts';
+import { parseDate } from '../../timeUtils.ts';
 
 interface VideoMap {
   [link: string]: VideoData;
@@ -11,17 +12,17 @@ interface VideoMap {
 function validateAndFormatDate(rawDate: any, videoTitle: string): string {
   if (!rawDate) {
     console.warn('Missing date for video:', videoTitle);
-    return new Date().toISOString();
+    return '';
   }
 
   try {
-    const date = new Date(rawDate);
-    if (isNaN(date.getTime())) {
+    const date = parseDate(String(rawDate));
+    if (!date) {
       console.warn('Invalid date for video:', {
         title: videoTitle,
         date: rawDate
       });
-      return new Date().toISOString();
+      return String(rawDate || '');
     }
     return date.toISOString();
   } catch (error) {
@@ -30,7 +31,7 @@ function validateAndFormatDate(rawDate: any, videoTitle: string): string {
       date: rawDate,
       error: error instanceof Error ? error.message : 'Unknown error'
     });
-    return new Date().toISOString();
+    return String(rawDate || '');
   }
 }
 

--- a/bolt-app/src/utils/sortUtils.ts
+++ b/bolt-app/src/utils/sortUtils.ts
@@ -1,6 +1,6 @@
-import { VideoData } from '../types/video';
-import { SortOptions } from '../types/sort';
-import { parseDate } from './timeUtils';
+import type { VideoData } from '../types/video.ts';
+import type { SortOptions } from '../types/sort.ts';
+import { parseDate } from './timeUtils.ts';
 
 export function sortVideos(videos: VideoData[], options: SortOptions | null): VideoData[] {
   if (!options) return videos;
@@ -11,15 +11,31 @@ export function sortVideos(videos: VideoData[], options: SortOptions | null): Vi
   });
 
   return [...videos].sort((a, b) => {
+    const field = options.field;
+    const rawA = a[field];
+    const rawB = b[field];
+
+    // Place les entrées sans date en fin de liste
+    if (!rawA || !rawB) {
+      console.warn('Missing date found during sort:', {
+        videoA: { title: a.title, date: rawA },
+        videoB: { title: b.title, date: rawB }
+      });
+      if (!rawA && !rawB) return 0;
+      if (!rawA) return 1;
+      if (!rawB) return -1;
+      return 0;
+    }
+
     // Parse les dates en utilisant la fonction parseDate qui gère tous les formats
-    const dateA = parseDate(a[options.field]);
-    const dateB = parseDate(b[options.field]);
+    const dateA = parseDate(rawA);
+    const dateB = parseDate(rawB);
 
     // Si une des dates est invalide, log l'erreur et place la vidéo à la fin
     if (!dateA || !dateB) {
       console.warn('Invalid date found during sort:', {
-        videoA: { title: a.title, date: a[options.field] },
-        videoB: { title: b.title, date: b[options.field] }
+        videoA: { title: a.title, date: rawA },
+        videoB: { title: b.title, date: rawB }
       });
       if (!dateA && !dateB) return 0;
       if (!dateA) return 1;
@@ -30,7 +46,7 @@ export function sortVideos(videos: VideoData[], options: SortOptions | null): Vi
     const timeA = dateA.getTime();
     const timeB = dateB.getTime();
 
-    return options.direction === 'desc' 
+    return options.direction === 'desc'
       ? timeB - timeA  // Plus récentes en premier
       : timeA - timeB; // Plus anciennes en premier
   });

--- a/bolt-app/src/utils/timeUtils.test.ts
+++ b/bolt-app/src/utils/timeUtils.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { parseDate, formatPublishDate } from './timeUtils.ts';
+import { sortVideos } from './sortUtils.ts';
 
 test('parseDate parses DD/MM/YYYY HH:MM format', () => {
   const result = parseDate('17/05/2024 14:30');
@@ -10,6 +11,14 @@ test('parseDate parses DD/MM/YYYY HH:MM format', () => {
   assert.equal(result?.getDate(), 17);
   assert.equal(result?.getHours(), 14);
   assert.equal(result?.getMinutes(), 30);
+});
+
+test('parseDate parses French date format', () => {
+  const result = parseDate('11 avril 2024');
+  assert.ok(result);
+  assert.equal(result?.getFullYear(), 2024);
+  assert.equal(result?.getMonth(), 3);
+  assert.equal(result?.getDate(), 11);
 });
 
 test('formatPublishDate handles minutes', () => {
@@ -62,4 +71,15 @@ test('formatPublishDate handles dates older than a week', () => {
   const dateString = `${dd}/${mm}/${yyyy} ${hh}:${min}`;
   const expected = new Intl.DateTimeFormat('fr-FR', { year: 'numeric', month: 'long', day: 'numeric' }).format(older);
   assert.equal(formatPublishDate(dateString), expected);
+});
+
+test('sortVideos orders videos by chronological publishedAt', () => {
+  const videos = [
+    { title: 'A', publishedAt: '11 avril 2024' },
+    { title: 'B', publishedAt: '10 avril 2024' },
+    { title: 'C', publishedAt: '' }
+  ];
+
+  const sorted = sortVideos(videos as any, { field: 'publishedAt', direction: 'asc' });
+  assert.deepEqual(sorted.map(v => v.title), ['B', 'A', 'C']);
 });


### PR DESCRIPTION
## Summary
- Use `parseDate` when syncing sheet dates and keep original value if parsing fails
- Push videos without publish dates to the end when sorting
- Add tests for French date parsing and chronological sorting

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ebcbba0c83209af75016af91b9a9