### PR TITLE
Afficher l'avatar de la chaîne dans les cartes vidéo

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -27,10 +27,10 @@ export function VideoCard({ video }: VideoCardProps) {
       onClick={handleClick}
       className="group cursor-pointer p-3 rounded-xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] bg-neu-base dark:bg-neutral-700/50 shadow-[2px_2px_4px_#d1d9e6,_-2px_-2px_4px_#ffffff] dark:shadow-[2px_2px_4px_rgba(0,0,0,0.2),_-2px_-2px_4px_rgba(255,255,255,0.05)] hover:shadow-[4px_4px_8px_#d1d9e6,_-4px_-4px_8px_#ffffff] dark:hover:shadow-[4px_4px_8px_rgba(0,0,0,0.25),_-4px_-4px_8px_rgba(255,255,255,0.1)] flex flex-col"
     >
-      <div className="relative aspect-video rounded-lg overflow-hidden mb-3 shadow-[inset_2px_2px_4px_rgba(209,217,230,0.4),_inset_-2px_-2px_4px_rgba(255,255,255,0.4)] dark:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.2),_inset_-2px_-2px_4px_rgba(255,255,255,0.05)]">
+      <div className="relative aspect-square rounded-full overflow-hidden mb-3 shadow-[inset_2px_2px_4px_rgba(209,217,230,0.4),_inset_-2px_-2px_4px_rgba(255,255,255,0.4)] dark:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.2),_inset_-2px_-2px_4px_rgba(255,255,255,0.05)]">
         <img
-          src={video.thumbnail}
-          alt={video.title}
+          src={video.channelAvatar}
+          alt={video.channel}
           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
         />
         <div className="absolute bottom-2 right-2 bg-black/80 px-2 py-0.5 text-white text-xs font-medium rounded">
@@ -44,13 +44,6 @@ export function VideoCard({ video }: VideoCardProps) {
         </h3>
 
         <div className="flex items-center text-[13px] text-youtube-gray-dark dark:text-gray-400 mb-1">
-          {video.channelAvatar && (
-            <img
-              src={video.channelAvatar}
-              alt={`${video.channel} avatar`}
-              className="w-6 h-6 rounded-full mr-2"
-            />
-          )}
           <div>{video.channel}</div>
         </div>
 

--- a/bolt-app/src/utils/api/sheets/local.ts
+++ b/bolt-app/src/utils/api/sheets/local.ts
@@ -2,7 +2,6 @@ import type { VideoData } from '../../../types/video.ts';
 import type { ApiResponse } from './types.ts';
 import { validateRow } from './validation.ts';
 import { mapRowToVideo } from './transform.ts';
-import { processVideoData } from '../../youtube.ts';
 
 export async function fetchLocalVideos(): Promise<ApiResponse<VideoData[]>> {
   try {
@@ -12,8 +11,7 @@ const baseUrl = (import.meta as any).env?.BASE_URL ?? '';
     const [, ...rows] = json as any[][]; // skip header row
     const videos = rows
       .filter(validateRow)
-      .map(mapRowToVideo)
-      .map(processVideoData);
+      .map(mapRowToVideo);
 
     return { data: videos };
   } catch (err) {

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -2,7 +2,6 @@ import { fetchSheetData } from './fetch.ts';
 import { SHEET_TABS } from '../../constants.ts';
 import type { VideoData } from '../../../types/video.ts';
 import { validateRow } from './validation.ts';
-import { processVideoData } from '../../youtube.ts';
 import { parseDate } from '../../timeUtils.ts';
 
 interface VideoMap {
@@ -77,7 +76,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
       
       validRows.forEach(row => {
         const [
-          thumbnail,
+          channelAvatar,
           title,
           link,
           channel,
@@ -89,7 +88,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
           description,
           tags,
           category,
-          channelAvatar
+          thumbnail
         ] = row.map(cell => String(cell || '').trim());
 
         if (!link || !link.includes('youtube.com')) {
@@ -99,7 +98,7 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
 
         if (!videoMap[link]) {
           const video: VideoData = {
-            thumbnail: thumbnail || '',
+            channelAvatar: channelAvatar || '',
             title: title || '',
             link,
             channel: channel || '',
@@ -111,10 +110,10 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
             shortDescription: description || '',
             tags: tags || '',
             category: category || 'Non catégorisé',
-            channelAvatar: channelAvatar || ''
+            thumbnail: thumbnail || ''
           };
 
-          videoMap[link] = processVideoData(video);
+          videoMap[link] = video;
         }
       });
     });

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -9,10 +9,10 @@ export function mapRowToVideo(row: any[]): VideoData {
   };
 
   return {
-    thumbnail: safeString(row[0]), // Column A
-    title: safeString(row[1]),     // Column B
-    link: safeString(row[2]),      // Column C
-    channel: safeString(row[3]),   // Column D
+    channelAvatar: safeString(row[0]), // Column A for channel avatar
+    title: safeString(row[1]),         // Column B
+    link: safeString(row[2]),          // Column C
+    channel: safeString(row[3]),       // Column D
     publishedAt: safeString(row[4], new Date().toISOString()),
     duration: safeString(row[5], '00:00'),
     views: safeString(row[6], '0'),
@@ -21,6 +21,6 @@ export function mapRowToVideo(row: any[]): VideoData {
     shortDescription: safeString(row[9]),
     tags: safeString(row[10]),
     category: safeString(row[11], 'Non catégorisé'), // Column L for category
-    channelAvatar: safeString(row[12]), // Column M for channel avatar
+    thumbnail: safeString(row[12]), // Column M for thumbnail
   };
 }

--- a/bolt-app/src/utils/api/sheets/validation.ts
+++ b/bolt-app/src/utils/api/sheets/validation.ts
@@ -8,29 +8,30 @@ export function validateRow(row: any[]): boolean {
 
   const title = String(row[1] || '').trim();
   const link = String(row[2] || '').trim();
-  const thumbnail = String(row[0] || '').trim(); // Validate thumbnail from column A
-  const channelAvatar = String(row[12] || '').trim(); // Validate channel avatar from column M
+  const channelAvatar = String(row[0] || '').trim(); // Validate channel avatar from column A
+  const thumbnail = String(row[12] || '').trim(); // Validate thumbnail from column M
 
   const hasTitleAndLink = title !== '' && link !== '';
   const hasValidLinkFormat = link.startsWith('http://') ||
                             link.startsWith('https://') ||
                             link.startsWith('www.');
-  const hasValidThumbnail = thumbnail.startsWith('http://') ||
-                           thumbnail.startsWith('https://');
   const hasValidAvatar = channelAvatar === '' ||
                          channelAvatar.startsWith('http://') ||
                          channelAvatar.startsWith('https://');
-
-  if (!hasValidThumbnail) {
-    console.warn('Invalid thumbnail URL:', {
-      thumbnail,
-      rowIndex: row[0] ? `Row with title ${row[1]}` : 'Unknown row'
-    });
-  }
+  const hasValidThumbnail = thumbnail === '' ||
+                           thumbnail.startsWith('http://') ||
+                           thumbnail.startsWith('https://');
 
   if (!hasValidAvatar && channelAvatar) {
     console.warn('Invalid channel avatar URL:', {
       channelAvatar,
+      rowIndex: row[0] ? `Row with title ${row[1]}` : 'Unknown row'
+    });
+  }
+
+  if (!hasValidThumbnail && thumbnail) {
+    console.warn('Invalid thumbnail URL:', {
+      thumbnail,
       rowIndex: row[0] ? `Row with title ${row[1]}` : 'Unknown row'
     });
   }
@@ -41,12 +42,12 @@ export function validateRow(row: any[]): boolean {
     console.warn('Row validation failed:', {
       hasTitleAndLink,
       hasValidLinkFormat,
-      hasValidThumbnail,
       hasValidAvatar,
+      hasValidThumbnail,
       title,
       link,
-      thumbnail,
       channelAvatar,
+      thumbnail,
       reason: !hasTitleAndLink ? 'Missing title or link' : 'Invalid link format'
     });
   }

--- a/bolt-app/src/utils/youtube.test.ts
+++ b/bolt-app/src/utils/youtube.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { extractYouTubeId, generateThumbnail } from './youtube.ts';
+import { extractYouTubeId } from './youtube.ts';
 
 test('extractYouTubeId preserves mixed-case video IDs', () => {
   const url = 'https://YouTube.com/watch?v=aBcDeFgHiJk';
@@ -8,8 +8,3 @@ test('extractYouTubeId preserves mixed-case video IDs', () => {
   assert.equal(id, 'aBcDeFgHiJk');
 });
 
-test('generateThumbnail returns valid URL for mixed-case IDs', () => {
-  const url = 'https://YoUtU.Be/aBcDeFgHiJk';
-  const thumbnail = generateThumbnail(url);
-  assert.equal(thumbnail, 'https://img.youtube.com/vi/aBcDeFgHiJk/hqdefault.jpg');
-});

--- a/bolt-app/src/utils/youtube.ts
+++ b/bolt-app/src/utils/youtube.ts
@@ -1,4 +1,3 @@
-import type { VideoData } from '../types/video.ts';
 
 // Supported YouTube URL patterns
 const URL_PATTERNS = {
@@ -38,37 +37,3 @@ export function extractYouTubeId(url: string): string | null {
   }
 }
 
-/**
- * Generates thumbnail URL for a YouTube video
- * Uses hqdefault.jpg as it's more reliable than maxresdefault.jpg
- */
-export function generateThumbnail(url: string): string {
-  const videoId = extractYouTubeId(url);
-  if (!videoId) {
-    console.warn('Could not generate thumbnail - invalid YouTube URL:', url);
-    return '';
-  }
-  
-  // Use hqdefault.jpg for better reliability
-  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-}
-
-/**
- * Validates and processes video data to ensure proper thumbnail URLs
- */
-export function processVideoData(video: VideoData): VideoData {
-  // Generate thumbnail if not provided or invalid
-  if (!video.thumbnail || !video.thumbnail.includes('youtube.com')) {
-    const newThumbnail = generateThumbnail(video.link);
-    if (newThumbnail) {
-      console.log('Generated new thumbnail for video:', {
-        title: video.title,
-        oldThumbnail: video.thumbnail,
-        newThumbnail
-      });
-      return { ...video, thumbnail: newThumbnail };
-    }
-  }
-  
-  return video;
-}

--- a/local.ts
+++ b/local.ts
@@ -2,7 +2,6 @@ import type { VideoData } from '../../../types/video.ts';
 import type { ApiResponse } from './types.ts';
 import { validateRow } from './validation.ts';
 import { mapRowToVideo } from './transform.ts';
-import { processVideoData } from '../../youtube.ts';
 
 /**
  * Fetches a local JSON file containing video rows and converts it into an array
@@ -28,8 +27,7 @@ export async function fetchLocalVideos(): Promise<ApiResponse<VideoData[]>> {
     const [, ...rows] = json as any[][]; // skip header row
     const videos = rows
       .filter(validateRow)
-      .map(mapRowToVideo)
-      .map(processVideoData);
+      .map(mapRowToVideo);
 
     return { data: videos };
   } catch (err) {

--- a/youtube.ts
+++ b/youtube.ts
@@ -1,4 +1,3 @@
-import type { VideoData } from '../types/video.ts';
 
 // Définition des différents formats de liens YouTube pris en charge. Les
 // expressions régulières capturent l'identifiant de la vidéo ou de la playlist
@@ -37,49 +36,4 @@ export function extractYouTubeId(url: string): string | null {
     });
     return null;
   }
-}
-
-/**
- * Génère l'URL de la miniature (hqdefault) pour une vidéo YouTube.
- * Retourne une chaîne vide si l'URL fournie est invalide ou ne contient
- * pas d'identifiant reconnaissable.
- *
- * @param url L'URL d'origine de la vidéo YouTube
- */
-export function generateThumbnail(url: string): string {
-  const videoId = extractYouTubeId(url);
-  if (!videoId) {
-    console.warn('Could not generate thumbnail - invalid YouTube URL:', url);
-    return '';
-  }
-  return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-}
-
-/**
- * Valide et enrichit un objet `VideoData` en corrigeant la miniature si
- * nécessaire. Si la miniature fournie n'existe pas ou ne provient pas des
- * domaines d'images YouTube officiels (`img.youtube.com` ou `ytimg.com`),
- * une nouvelle miniature est générée à partir du lien de la vidéo.
- *
- * @param video Les données vidéo à traiter
- */
-export function processVideoData(video: VideoData): VideoData {
-  // Vérifie si la miniature existe et pointe vers un domaine valide de YouTube
-  const hasValidThumbnail =
-    typeof video.thumbnail === 'string' &&
-    /(img\.youtube\.com|ytimg\.com)/.test(video.thumbnail);
-
-  if (!hasValidThumbnail) {
-    const newThumbnail = generateThumbnail(video.link);
-    if (newThumbnail) {
-      console.log('Generated new thumbnail for video:', {
-        title: video.title,
-        oldThumbnail: video.thumbnail,
-        newThumbnail
-      });
-      return { ...video, thumbnail: newThumbnail };
-    }
-  }
-  // Aucune modification si la miniature est déjà considérée comme valide.
-  return video;
 }


### PR DESCRIPTION
## Résumé
- Remplace l'image principale d'une carte vidéo par l'avatar de la chaîne et supprime l'avatar dupliqué.
- Ajuste la synchronisation et la validation des données pour lire l'avatar en première colonne.
- Retire les utilitaires obsolètes de génération de miniatures.

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2edcd5c348320b1422b7fd264f6e6