### PR TITLE
feat: restore video thumbnail and overlay channel avatar

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -27,11 +27,16 @@ export function VideoCard({ video }: VideoCardProps) {
       onClick={handleClick}
       className="group cursor-pointer p-3 rounded-xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] bg-neu-base dark:bg-neutral-700/50 shadow-[2px_2px_4px_#d1d9e6,_-2px_-2px_4px_#ffffff] dark:shadow-[2px_2px_4px_rgba(0,0,0,0.2),_-2px_-2px_4px_rgba(255,255,255,0.05)] hover:shadow-[4px_4px_8px_#d1d9e6,_-4px_-4px_8px_#ffffff] dark:hover:shadow-[4px_4px_8px_rgba(0,0,0,0.25),_-4px_-4px_8px_rgba(255,255,255,0.1)] flex flex-col"
     >
-      <div className="relative aspect-square rounded-full overflow-hidden mb-3 shadow-[inset_2px_2px_4px_rgba(209,217,230,0.4),_inset_-2px_-2px_4px_rgba(255,255,255,0.4)] dark:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.2),_inset_-2px_-2px_4px_rgba(255,255,255,0.05)]">
+      <div className="relative aspect-video rounded-xl overflow-hidden mb-3 shadow-[inset_2px_2px_4px_rgba(209,217,230,0.4),_inset_-2px_-2px_4px_rgba(255,255,255,0.4)] dark:shadow-[inset_2px_2px_4px_rgba(0,0,0,0.2),_inset_-2px_-2px_4px_rgba(255,255,255,0.05)]">
+        <img
+          src={video.thumbnail}
+          alt={video.title}
+          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+        />
         <img
           src={video.channelAvatar}
           alt={video.channel}
-          className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+          className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
         />
         <div className="absolute bottom-2 right-2 bg-black/80 px-2 py-0.5 text-white text-xs font-medium rounded">
           {formatDuration(video.duration)}


### PR DESCRIPTION
## Summary
- use video.thumbnail as main image in video card
- overlay channel avatar with proper positioning
- confirm channel avatar remains optional in sheet validation

## Testing
- `npm --prefix bolt-app run lint`
- `npm --prefix bolt-app test`


------
https://chatgpt.com/codex/tasks/task_e_68b2efd279648320b77b6566b0399e41