### PR TITLE
Wrap channel avatar image in conditional block

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -33,11 +33,13 @@ export function VideoCard({ video }: VideoCardProps) {
           alt={video.title}
           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
         />
-        <img
-          src={video.channelAvatar}
-          alt={video.channel}
-          className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
-        />
+        {video.channelAvatar && (
+          <img
+            src={video.channelAvatar}
+            alt={video.channel}
+            className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
+          />
+        )}
         <div className="absolute bottom-2 right-2 bg-black/80 px-2 py-0.5 text-white text-xs font-medium rounded">
           {formatDuration(video.duration)}
         </div>


### PR DESCRIPTION
## Summary
- render channel avatar only when available in video card

## Testing
- `cd bolt-app && npm run lint`
- `cd bolt-app && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f5b08b4483208827d45c0aff803f