### PR TITLE
Rendre channelAvatar optionnel dans VideoData

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -34,7 +34,7 @@ export function VideoCard({ video }: VideoCardProps) {
           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
         />
         <img
-          src={video.channelAvatar}
+          src={video.channelAvatar ?? ''}
           alt={video.channel}
           className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
         />

--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -1,5 +1,5 @@
 export interface VideoData {
-  channelAvatar: string;  // Colonne A
+  channelAvatar?: string;  // Colonne A
   title: string;          // Colonne B
   link: string;           // Colonne C
   channel: string;        // Colonne D


### PR DESCRIPTION
## Résumé
- Rendre le champ `channelAvatar` optionnel dans l’interface `VideoData`
- Gérer l’absence d’avatar de chaîne dans `VideoCard`

## Tests
- `npm --prefix bolt-app test`
- `npm --prefix bolt-app run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f5b3f1e4832091f5722808771feb