### PR TITLE
Rendre channelAvatar optionnel dans VideoData

### DIFF
--- a/bolt-app/src/components/VideoCard.tsx
+++ b/bolt-app/src/components/VideoCard.tsx
@@ -33,11 +33,13 @@ export function VideoCard({ video }: VideoCardProps) {
           alt={video.title}
           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
         />
-        <img
-          src={video.channelAvatar}
-          alt={video.channel}
-          className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
-        />
+        {video.channelAvatar && (
+          <img
+            src={video.channelAvatar}
+            alt={video.channel}
+            className="absolute bottom-2 left-2 w-8 h-8 rounded-full border border-white shadow-md"
+          />
+        )}
         <div className="absolute bottom-2 right-2 bg-black/80 px-2 py-0.5 text-white text-xs font-medium rounded">
           {formatDuration(video.duration)}
         </div>

--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -1,5 +1,5 @@
 export interface VideoData {
-  channelAvatar: string;  // Colonne A
+  channelAvatar?: string;  // Colonne A
   title: string;          // Colonne B
   link: string;           // Colonne C
   channel: string;        // Colonne D


### PR DESCRIPTION
## Résumé
- Rendre le champ `channelAvatar` optionnel dans l’interface `VideoData`
- Afficher l’avatar de chaîne uniquement lorsqu’il est disponible

## Tests
- `npm --prefix bolt-app test`
- `npm --prefix bolt-app run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f5b3f1e4832091f5722808771feb