### PR TITLE
Améliore la résilience de la pagination des playlists

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,8 @@ def fetch_all_playlist_items(playlist_id: str, api_key: str, max_retries: int = 
     """
     Récupère tous les items d’une playlist YouTube en gérant la pagination,
     avec gestion d’erreurs réseau et backoff exponentiel.
+
+    Lève RuntimeError si toutes les tentatives pour récupérer une page échouent.
     """
     base_url = "https://www.googleapis.com/youtube/v3/playlistItems"
     params = {
@@ -132,7 +134,13 @@ def fetch_all_playlist_items(playlist_id: str, api_key: str, max_retries: int = 
             except Exception as err:
                 logging.warning("Erreur API YouTube (playlistItems): %s", err)
                 if attempt == max_retries - 1:
-                    return items
+                    logging.error(
+                        "Toutes les tentatives (%s) ont échoué pour récupérer les items de la playlist.",
+                        max_retries,
+                    )
+                    raise RuntimeError(
+                        "Échec de récupération des items de la playlist"
+                    ) from err
                 time.sleep(backoff)
                 backoff = min(backoff * 2, 60)
 

--- a/tests/test_fetch_retries.py
+++ b/tests/test_fetch_retries.py
@@ -1,8 +1,10 @@
+import logging
 import requests
+import pytest
 from main import fetch_all_playlist_items, fetch_videos_details
 
 
-def test_fetch_all_playlist_items_max_retries(monkeypatch):
+def test_fetch_all_playlist_items_max_retries(monkeypatch, caplog):
     calls = {"count": 0}
 
     def fake_get(url, params=None, timeout=None):
@@ -10,9 +12,11 @@ def test_fetch_all_playlist_items_max_retries(monkeypatch):
         raise requests.RequestException("boom")
 
     monkeypatch.setattr(requests, "get", fake_get)
-    items = fetch_all_playlist_items("playlist", "key", max_retries=3)
-    assert items == []
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            fetch_all_playlist_items("playlist", "key", max_retries=3)
     assert calls["count"] == 3
+    assert "Toutes les tentatives" in caplog.text
 
 
 def test_fetch_videos_details_max_retries(monkeypatch):


### PR DESCRIPTION
## Résumé
- Ajout d'une erreur explicite lorsque toutes les tentatives de requête `playlistItems` échouent.
- Journalisation d'un message d'erreur détaillé pour les échecs de pagination.
- Mise à jour des tests pour vérifier l'exception et la présence du log.

## Tests
- `python -m py_compile main.py tests/test_fetch_retries.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33f27fb108320970841f0f96ad251