### PR TITLE
Ajout de l'authentification OAuth pour la lecture de playlists privées

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Secrets GitHub à créer :
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
+### Authentification YouTube (OAuth 2.0)
+
+Pour accéder aux playlists **privées** de l’utilisateur, le script utilise OAuth 2.0 :
+
+1. Crée un identifiant OAuth de type « Application installée » dans la console Google Cloud et télécharge le fichier `client_secret.json`.
+2. Place ce fichier à la racine du projet.
+3. Au premier lancement, exécute `main.py` : une fenêtre de navigateur s’ouvre pour autoriser l’accès.
+4. Un fichier `token.json` est généré et réutilisé pour les exécutions suivantes.
+
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
   (25 à 60 caractères alphanumériques, tirets ou soulignés)

--- a/tests/test_fetch_retries.py
+++ b/tests/test_fetch_retries.py
@@ -2,15 +2,33 @@ import requests
 from main import fetch_all_playlist_items, fetch_videos_details
 
 
-def test_fetch_all_playlist_items_max_retries(monkeypatch):
+def test_fetch_all_playlist_items_max_retries():
     calls = {"count": 0}
 
-    def fake_get(url, params=None, timeout=None):
-        calls["count"] += 1
-        raise requests.RequestException("boom")
+    class FailingRequest:
+        def __init__(self, calls):
+            self.calls = calls
 
-    monkeypatch.setattr(requests, "get", fake_get)
-    items = fetch_all_playlist_items("playlist", "key", max_retries=3)
+        def execute(self):
+            self.calls["count"] += 1
+            raise Exception("boom")
+
+    class FailingPlaylistItems:
+        def __init__(self, calls):
+            self.calls = calls
+
+        def list(self, **kwargs):
+            return FailingRequest(self.calls)
+
+    class FailingService:
+        def __init__(self, calls):
+            self.calls = calls
+
+        def playlistItems(self):
+            return FailingPlaylistItems(self.calls)
+
+    service = FailingService(calls)
+    items = fetch_all_playlist_items("playlist", service, max_retries=3)
     assert items == []
     assert calls["count"] == 3
 


### PR DESCRIPTION
## Résumé
- Intégration d'un flux OAuth 2.0 pour obtenir un client YouTube autorisé
- Remplacement de l'appel HTTP brut par l'API YouTube autorisée dans `fetch_all_playlist_items`
- Documentation de la procédure d'authentification dans le README

## Test
- `python -m py_compile main.py tests/test_fetch_retries.py`
- `pytest`
- `pip install flake8` *(échec : 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f33ae948320b85b0c4f86f9b706