### PR TITLE
Gère l'échec de récupération des playlists

### DIFF
--- a/tests/test_fetch_retries.py
+++ b/tests/test_fetch_retries.py
@@ -1,8 +1,10 @@
+import logging
 import requests
+import pytest
 from main import fetch_all_playlist_items, fetch_videos_details
 
 
-def test_fetch_all_playlist_items_max_retries(monkeypatch):
+def test_fetch_all_playlist_items_max_retries(monkeypatch, caplog):
     calls = {"count": 0}
 
     def fake_get(url, params=None, timeout=None):
@@ -10,9 +12,11 @@ def test_fetch_all_playlist_items_max_retries(monkeypatch):
         raise requests.RequestException("boom")
 
     monkeypatch.setattr(requests, "get", fake_get)
-    items = fetch_all_playlist_items("playlist", "key", max_retries=3)
-    assert items == []
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError):
+            fetch_all_playlist_items("playlist", "key", max_retries=3)
     assert calls["count"] == 3
+    assert "Toutes les tentatives" in caplog.text
 
 
 def test_fetch_videos_details_max_retries(monkeypatch):

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -1,0 +1,23 @@
+import logging
+from main import sync_videos
+
+
+def test_sync_videos_handles_fetch_error(monkeypatch, caplog):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "key")
+    monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
+    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", "dummy.json")
+
+    monkeypatch.setattr(
+        "main.service_account.Credentials.from_service_account_file",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr("main.build", lambda *a, **k: None)
+
+    def fake_fetch(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("main.fetch_all_playlist_items", fake_fetch)
+
+    with caplog.at_level(logging.ERROR):
+        sync_videos()
+    assert "Impossible de récupérer les vidéos de la playlist" in caplog.text


### PR DESCRIPTION
## Résumé
- Gestion explicite des erreurs lors de la récupération de la playlist pour éviter les plantages
- Ajout d'un test vérifiant la journalisation et l'arrêt propre de `sync_videos`

## Tests
- `flake8 .` *(échoué : commande introuvable)*
- `python -m py_compile main.py tests/test_sync_videos_error.py tests/test_fetch_retries.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33f27fb108320970841f0f96ad251