### PR TITLE
Remove separate playlist ID secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Secrets GitHub à créer :
   (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
+La même valeur `SPREADSHEET_ID` est également utilisée pour identifier la playlist YouTube à synchroniser.
+
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -2,10 +2,12 @@ import logging
 from main import sync_videos
 
 
-def test_sync_videos_handles_fetch_error(monkeypatch, caplog):
+def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("YOUTUBE_API_KEY", "key")
     monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
-    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", "dummy.json")
+    service_file = tmp_path / "dummy.json"
+    service_file.write_text("{}")
+    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", str(service_file))
 
     monkeypatch.setattr(
         "main.service_account.Credentials.from_service_account_file",


### PR DESCRIPTION
## Summary
- Drop use of PLAYLIST_ID and reuse SPREADSHEET_ID as the playlist identifier
- Adjust tests and docs to reflect the absence of a dedicated playlist secret

## Testing
- `ruff check main.py tests/test_sync_videos_error.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b414dae11083209aefab92602fa7cd