### PR TITLE
Remove separate playlist ID secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Secrets GitHub à créer :
   (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
+La même valeur `SPREADSHEET_ID` est également utilisée pour identifier la playlist YouTube à synchroniser.
+
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :

--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ def ensure_sheet_exists(service, spreadsheet_id: str, sheet_name: str) -> int:
         raise RuntimeError(f"Impossible de créer l’onglet '{sheet_name}'.")
     return sheet_id
 
-def fetch_all_playlist_items(playlist_id: str, api_key: str, max_retries: int = 5) -> list[dict]:
+def fetch_all_playlist_items(source_id: str, api_key: str, max_retries: int = 5) -> list[dict]:
     """
     Récupère tous les items d’une playlist YouTube en gérant la pagination,
     avec gestion d’erreurs réseau et backoff exponentiel.
@@ -108,7 +108,7 @@ def fetch_all_playlist_items(playlist_id: str, api_key: str, max_retries: int = 
     base_url = "https://www.googleapis.com/youtube/v3/playlistItems"
     params = {
         "part": "snippet,contentDetails",
-        "playlistId": playlist_id,
+        "playlistId": source_id,
         "maxResults": 50,
         "key": api_key,
     }
@@ -224,42 +224,13 @@ def sync_videos() -> None:
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     raw_spreadsheet_id = os.environ.get("SPREADSHEET_ID")
     SHEET_TAB_NAME = os.environ.get("SHEET_TAB_NAME", "AllVideos")
-    # Nettoyage de l'ID de playlist
-    raw_playlist = os.environ.get("PLAYLIST_ID", "")
-    PLAYLIST_ID = raw_playlist.strip()
-    # Si aucun identifiant de playlist n'est fourni, on continue avec une chaîne vide.
-    # Une erreur générique sera consignée plus bas si la récupération échoue.
-    # Accepter un ID de chaîne (UC…) en récupérant la playlist 'uploads'
-    if PLAYLIST_ID.startswith("UC"):
-        try:
-            resp = requests.get(
-                "https://www.googleapis.com/youtube/v3/channels",
-                params={"part": "contentDetails", "id": PLAYLIST_ID, "key": YOUTUBE_API_KEY},
-                timeout=10,
-            )
-            resp.raise_for_status()
-            uploads = (
-                resp.json()
-                .get("items", [{}])[0]
-                .get("contentDetails", {})
-                .get("relatedPlaylists", {})
-                .get("uploads")
-            )
-            if uploads:
-                PLAYLIST_ID = uploads
-            else:
-                logging.error("Impossible de récupérer la playlist 'uploads' du canal %s", raw_playlist)
-                return
-        except Exception as e:
-            logging.error("Erreur lors de la récupération du canal %s : %s", raw_playlist, e)
-            return
     SERVICE_ACCOUNT_FILE = os.environ.get("SERVICE_ACCOUNT_FILE", "service_account.json")
+    if not raw_spreadsheet_id:
+        logging.error("Variable d'environnement SPREADSHEET_ID manquante")
+        return
     SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
     if not YOUTUBE_API_KEY:
         logging.error("Variable d'environnement YOUTUBE_API_KEY manquante")
-        return
-    if not raw_spreadsheet_id:
-        logging.error("Variable d'environnement SPREADSHEET_ID manquante")
         return
     SPREADSHEET_ID = parse_spreadsheet_id(raw_spreadsheet_id)
     if not SPREADSHEET_ID:
@@ -270,7 +241,7 @@ def sync_videos() -> None:
     service = build("sheets", "v4", credentials=creds)
     # Récupération des vidéos
     try:
-        items = fetch_all_playlist_items(PLAYLIST_ID, YOUTUBE_API_KEY)
+        items = fetch_all_playlist_items(SPREADSHEET_ID, YOUTUBE_API_KEY)
     except RuntimeError:
         # En cas d'erreur lors de la récupération, consigne un message générique
         logging.error("Impossible de récupérer les vidéos de la playlist")
@@ -278,7 +249,7 @@ def sync_videos() -> None:
     if not items:
         logging.warning(
             "Aucun élément récupéré pour la playlist %s. Vérifiez l'identifiant ou la visibilité.",
-            PLAYLIST_ID,
+            SPREADSHEET_ID,
         )
     video_ids = [it["contentDetails"]["videoId"] for it in items]
     videos_data = fetch_videos_details(video_ids, YOUTUBE_API_KEY)
@@ -359,3 +330,7 @@ def sync_videos() -> None:
         valueInputOption="RAW",
         body=body,
     ).execute()
+
+
+if __name__ == "__main__":
+    sync_videos()

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -2,10 +2,12 @@ import logging
 from main import sync_videos
 
 
-def test_sync_videos_handles_fetch_error(monkeypatch, caplog):
+def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("YOUTUBE_API_KEY", "key")
     monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
-    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", "dummy.json")
+    service_file = tmp_path / "dummy.json"
+    service_file.write_text("{}")
+    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", str(service_file))
 
     monkeypatch.setattr(
         "main.service_account.Credentials.from_service_account_file",


### PR DESCRIPTION
## Summary
- Drop use of PLAYLIST_ID and reuse SPREADSHEET_ID as the playlist identifier
- Adjust tests and docs to reflect the absence of a dedicated playlist secret
- Fetch playlist items using the sanitized `SPREADSHEET_ID`

## Testing
- `ruff check main.py tests/test_sync_videos_error.py tests/test_fetch_retries.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b414dae11083209aefab92602fa7cd