### PR TITLE
Simplifie la détection du thème

### DIFF
--- a/bolt-app/src/hooks/useTheme.ts
+++ b/bolt-app/src/hooks/useTheme.ts
@@ -3,10 +3,6 @@ import { useCallback, useEffect, useState } from 'react';
 export function useTheme() {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme');
-      if (stored === 'light' || stored === 'dark') {
-        return stored;
-      }
       return window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'dark'
         : 'light';
@@ -21,7 +17,6 @@ export function useTheme() {
     } else {
       root.classList.remove('dark');
     }
-    localStorage.setItem('theme', theme);
   }, [theme]);
 
   useEffect(() => {


### PR DESCRIPTION
## Résumé
- Détecte le thème par défaut uniquement via `window.matchMedia` sans stocker l’option en localStorage.
- Supprime la persistance du thème dans `localStorage` lors de l’application de la classe `dark`.

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4451fd8b08320b2821e2de39e6dcd