### PR TITLE
Sépare l'identifiant de playlist et lit les identifiants de service via l'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ Secrets GitHub à créer :
   (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
-La même valeur `SPREADSHEET_ID` est également utilisée pour identifier la playlist YouTube à synchroniser.
+Variables d’environnement supplémentaires :
+- `PLAYLIST_ID` — identifiant de la playlist YouTube à synchroniser (peut être défini comme variable GitHub non secrète)
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
+Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : aucun fichier local n’est requis.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
   (25 à 60 caractères alphanumériques, tirets ou soulignés)
-- `VITE_API_KEY` — clé API Google Sheets
+- `VITE_API_KEY` — clé API Google Sheets (ne pas réutiliser `YOUTUBE_API_KEY`)
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées (un modèle
 est fourni dans `.env.example`). L’application échouera au démarrage si l’une de

--- a/constants.ts
+++ b/constants.ts
@@ -83,15 +83,15 @@ const rawSpreadsheetId =
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 
 // Derive the API key. When deploying via GitHub Actions, the secrets are
-// injected as environment variables without the VITE_ prefix (e.g. YOUTUBE_API_KEY).
-// We therefore check the common names in order of specificity.  A query
-// parameter always overrides environment variables.
+// injected as environment variables without the VITE_ prefix. We therefore
+// check the common names in order of specificity. Uniquement les variables
+// dédiées à Google Sheets sont prises en compte.
+// A query parameter always overrides environment variables.
 export const API_KEY =
   apiKeyParam ||
   env.VITE_API_KEY ||
   env.API_KEY ||
   env.REACT_APP_API_KEY ||
-  env.YOUTUBE_API_KEY ||
   '';
 
 /**
@@ -128,11 +128,10 @@ export function getConfig(): {
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
   // If the API key is missing, signal it explicitly. Mention the supported
-  // environment variable names (VITE_API_KEY or YOUTUBE_API_KEY) to help
-  // repository owners configure secrets correctly.
+  // environment variable names to help repository owners configure secrets correctly.
   if (!API_KEY) {
     const error =
-      'API_KEY manquant : définissez VITE_API_KEY, YOUTUBE_API_KEY ou utilisez ?apiKey=';
+      'API_KEY manquant : définissez VITE_API_KEY ou API_KEY, ou utilisez ?apiKey=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import logging
+import json
 from datetime import datetime
 
 import requests
@@ -223,10 +224,12 @@ def sync_videos() -> None:
     # Variables d’environnement
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     raw_spreadsheet_id = os.environ.get("SPREADSHEET_ID")
+    playlist_source_id = os.environ.get("PLAYLIST_ID")
     SHEET_TAB_NAME = os.environ.get("SHEET_TAB_NAME", "AllVideos")
-    SERVICE_ACCOUNT_FILE = os.environ.get("SERVICE_ACCOUNT_FILE", "service_account.json")
-    playlist_source_id = raw_spreadsheet_id
     if not playlist_source_id:
+        logging.error("Variable d'environnement PLAYLIST_ID manquante")
+        return
+    if not raw_spreadsheet_id:
         logging.error("Variable d'environnement SPREADSHEET_ID manquante")
         return
     SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
@@ -237,8 +240,16 @@ def sync_videos() -> None:
     if not SPREADSHEET_ID:
         logging.error("SPREADSHEET_ID invalide")
         return
-    # Authentification Google Sheets
-    creds = service_account.Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+    service_account_json = os.environ.get("SERVICE_ACCOUNT_JSON")
+    if not service_account_json:
+        logging.error("Variable d'environnement SERVICE_ACCOUNT_JSON manquante")
+        return
+    try:
+        creds_info = json.loads(service_account_json)
+    except json.JSONDecodeError:
+        logging.error("SERVICE_ACCOUNT_JSON invalide")
+        return
+    creds = service_account.Credentials.from_service_account_info(creds_info, scopes=SCOPES)
     service = build("sheets", "v4", credentials=creds)
     # Récupération des vidéos
     try:

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -5,12 +5,11 @@ from main import sync_videos
 def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("YOUTUBE_API_KEY", "key")
     monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
-    service_file = tmp_path / "dummy.json"
-    service_file.write_text("{}")
-    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", str(service_file))
+    monkeypatch.setenv("PLAYLIST_ID", "PL123")
+    monkeypatch.setenv("SERVICE_ACCOUNT_JSON", "{}")
 
     monkeypatch.setattr(
-        "main.service_account.Credentials.from_service_account_file",
+        "main.service_account.Credentials.from_service_account_info",
         lambda *a, **k: object(),
     )
     monkeypatch.setattr("main.build", lambda *a, **k: None)


### PR DESCRIPTION
## Résumé
- ajoute la variable d'environnement `PLAYLIST_ID` et lit `SERVICE_ACCOUNT_JSON` sans fichier
- retire le repli `YOUTUBE_API_KEY` pour l'API Google Sheets
- documente les nouvelles variables et ajuste les tests

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `node ./bolt-app/node_modules/.bin/eslint constants.ts --config ./bolt-app/eslint.config.js --no-ignore`
- `npm --prefix bolt-app run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b446deaad883209acac0f49a569206