### PR TITLE
Sépare l'identifiant de playlist et lit les identifiants de service via l'environnement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,23 @@ Secrets GitHub à créer :
   (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
-La même valeur `SPREADSHEET_ID` est également utilisée pour identifier la playlist YouTube à synchroniser.
+Variables d’environnement supplémentaires :
+- `PLAYLIST_ID` — identifiant **ou URL complète** de la playlist YouTube à synchroniser (peut être défini comme variable GitHub non secrète)
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
+Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : aucun fichier local n’est requis.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
   (25 à 60 caractères alphanumériques, tirets ou soulignés)
-- `VITE_API_KEY` — clé API Google Sheets
+- `VITE_YOUTUBE_API_KEY` — clé API Google Sheets/YouTube (même valeur que `YOUTUBE_API_KEY`)
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées (un modèle
 est fourni dans `.env.example`). L’application échouera au démarrage si l’une de
 ces variables est absente.
 
 Seules les variables préfixées par `VITE_` sont exposées côté client ; des noms
-comme `SPREADSHEET_ID` ou `API_KEY` ne seront pas accessibles.
+comme `SPREADSHEET_ID` ou `YOUTUBE_API_KEY` ne seront pas accessibles.
 
 Pour des tests rapides, ces valeurs peuvent aussi être fournies via l’URL :
 `?spreadsheetId=` et `?apiKey=`.

--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -7,9 +7,9 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
   const rows = Array.from({ length: 1201 }, () => ['value']);
 
   const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_API_KEY;
+  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
   process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_API_KEY = 'test-key';
+  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
 
   try {
     const { fetchSheetData } = await import('./fetch.ts');
@@ -30,9 +30,9 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
       process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_API_KEY;
+      delete process.env.VITE_YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_API_KEY = originalApiKey;
+      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -21,9 +21,9 @@ test('synchronizeSheets handles large sheet ranges', async () => {
   ]);
 
   const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_API_KEY;
+  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
   process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_API_KEY = 'test-key';
+  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
 
   const { synchronizeSheets } = await import('./sync.ts');
   const { SHEET_TABS } = await import('../../constants.ts');
@@ -49,9 +49,9 @@ test('synchronizeSheets handles large sheet ranges', async () => {
       process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_API_KEY;
+      delete process.env.VITE_YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_API_KEY = originalApiKey;
+      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -27,12 +27,10 @@ export function parseSpreadsheetId(input: string): string {
 const rawSpreadsheetId =
   env.VITE_SPREADSHEET_ID ??
   env.SPREADSHEET_ID ??
-  env.REACT_APP_SPREADSHEET_ID ??
   '';
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
-export const API_KEY =
-  env.VITE_API_KEY ?? env.API_KEY ?? env.REACT_APP_API_KEY ?? '';
+export const API_KEY = env.VITE_YOUTUBE_API_KEY ?? env.YOUTUBE_API_KEY ?? '';
 
 /**
  * Valide l’ID : il doit contenir au moins un caractère et ne comporter que
@@ -61,7 +59,7 @@ export function getConfig(): {
   }
   // Si la clé API est absente, on l’indique.
   if (!API_KEY) {
-    const error = 'API_KEY manquant';
+    const error = 'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }

--- a/constants.ts
+++ b/constants.ts
@@ -65,9 +65,9 @@ function deriveConfigFromParams() {
 const { spreadsheetIdParam, apiKeyParam } = deriveConfigFromParams();
 
 // Determine the raw spreadsheet ID by preferring the query parameter over
-// environment variables. Accept both `VITE_SPREADSHEET_ID` and un-prefixed
-// versions for convenience. If nothing is provided, the string will be
-// empty and will trigger a configuration error later.
+// environment variables. Accept both `VITE_SPREADSHEET_ID` and `SPREADSHEET_ID`.
+// If nothing is provided, the string will be empty and will trigger a
+// configuration error later.
 const rawSpreadsheetId =
   // Prefer the ID from the query string over any environment variable.  In
   // production builds, only variables prefixed with VITE_ are exposed to
@@ -77,20 +77,16 @@ const rawSpreadsheetId =
   spreadsheetIdParam ||
   env.VITE_SPREADSHEET_ID ||
   env.SPREADSHEET_ID ||
-  env.REACT_APP_SPREADSHEET_ID ||
   '';
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 
-// Derive the API key. When deploying via GitHub Actions, the secrets are
-// injected as environment variables without the VITE_ prefix (e.g. YOUTUBE_API_KEY).
-// We therefore check the common names in order of specificity.  A query
-// parameter always overrides environment variables.
+// Derive the API key. A query parameter always overrides environment
+// variables. Seules les variables `VITE_YOUTUBE_API_KEY` ou
+// `YOUTUBE_API_KEY` sont prises en compte côté environnement.
 export const API_KEY =
   apiKeyParam ||
-  env.VITE_API_KEY ||
-  env.API_KEY ||
-  env.REACT_APP_API_KEY ||
+  env.VITE_YOUTUBE_API_KEY ||
   env.YOUTUBE_API_KEY ||
   '';
 
@@ -127,12 +123,9 @@ export function getConfig(): {
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
-  // If the API key is missing, signal it explicitly. Mention the supported
-  // environment variable names (VITE_API_KEY or YOUTUBE_API_KEY) to help
-  // repository owners configure secrets correctly.
+  // If the API key is missing, signal it explicitly.
   if (!API_KEY) {
-    const error =
-      'API_KEY manquant : définissez VITE_API_KEY, YOUTUBE_API_KEY ou utilisez ?apiKey=';
+    const error = 'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY, ou utilisez ?apiKey=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }

--- a/tests/test_parse_playlist_id.py
+++ b/tests/test_parse_playlist_id.py
@@ -1,0 +1,8 @@
+from main import parse_playlist_id
+
+def test_parse_playlist_id_accepts_url():
+    url = "https://www.youtube.com/playlist?list=PLabc1234567890"
+    assert parse_playlist_id(url) == "PLabc1234567890"
+
+def test_parse_playlist_id_rejects_invalid():
+    assert parse_playlist_id("invalid") is None

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -5,12 +5,11 @@ from main import sync_videos
 def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("YOUTUBE_API_KEY", "key")
     monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
-    service_file = tmp_path / "dummy.json"
-    service_file.write_text("{}")
-    monkeypatch.setenv("SERVICE_ACCOUNT_FILE", str(service_file))
+    monkeypatch.setenv("PLAYLIST_ID", "PL1234567890ABCDE")
+    monkeypatch.setenv("SERVICE_ACCOUNT_JSON", "{}")
 
     monkeypatch.setattr(
-        "main.service_account.Credentials.from_service_account_file",
+        "main.service_account.Credentials.from_service_account_info",
         lambda *a, **k: object(),
     )
     monkeypatch.setattr("main.build", lambda *a, **k: None)


### PR DESCRIPTION
## Résumé
- remplace toute référence à `VITE_API_KEY` par `VITE_YOUTUBE_API_KEY` ou `YOUTUBE_API_KEY`
- adapte les tests aux nouveaux noms de variables d'environnement
- documente l'unique secret `YOUTUBE_API_KEY` et son équivalent `VITE_YOUTUBE_API_KEY`

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `node ./bolt-app/node_modules/.bin/eslint constants.ts --config ./bolt-app/eslint.config.js --no-ignore`
- `npm --prefix bolt-app run lint`
- `npm --prefix bolt-app test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b446deaad883209acac0f49a569206