### PR TITLE
Support de PLAYLIST_ID via URL dans la synchronisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Non secret : identifiant ou URL de la playlist YouTube
+PLAYLIST_ID=your-playlist-id
+
 # Obligatoire : identifiant du Google Sheet
 VITE_SPREADSHEET_ID=your-spreadsheet-id
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Secrets GitHub à créer :
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
 Variables d’environnement supplémentaires :
-- `PLAYLIST_ID` — identifiant de la playlist YouTube à synchroniser (peut être défini comme variable GitHub non secrète)
+- `PLAYLIST_ID` — identifiant **ou URL complète** de la playlist YouTube à synchroniser (peut être défini comme variable GitHub non secrète)
 
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : aucun fichier local n’est requis.

--- a/main.py
+++ b/main.py
@@ -31,11 +31,22 @@ DEFAULT_THUMBNAIL_URL = "https://via.placeholder.com/480x360?text=No+Thumbnail"
 
 _SPREADSHEET_RE = re.compile(r"/spreadsheets/d/([A-Za-z0-9-_]{25,60})")
 
+_PLAYLIST_RE = re.compile(r"list=([A-Za-z0-9-_]{5,60})")
+
 def parse_spreadsheet_id(value: str) -> str | None:
     match = _SPREADSHEET_RE.search(value or "")
     if match:
         return match.group(1)
     if re.fullmatch(r"[A-Za-z0-9-_]{25,60}", value or ""):
+        return value.strip()
+    return None
+
+
+def parse_playlist_id(value: str) -> str | None:
+    match = _PLAYLIST_RE.search(value or "")
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[A-Za-z0-9-_]{5,60}", value or ""):
         return value.strip()
     return None
 
@@ -224,10 +235,14 @@ def sync_videos() -> None:
     # Variables d’environnement
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     raw_spreadsheet_id = os.environ.get("SPREADSHEET_ID")
-    playlist_source_id = os.environ.get("PLAYLIST_ID")
+    raw_playlist_id = os.environ.get("PLAYLIST_ID")
     SHEET_TAB_NAME = os.environ.get("SHEET_TAB_NAME", "AllVideos")
-    if not playlist_source_id:
+    if not raw_playlist_id:
         logging.error("Variable d'environnement PLAYLIST_ID manquante")
+        return
+    playlist_source_id = parse_playlist_id(raw_playlist_id)
+    if not playlist_source_id:
+        logging.error("PLAYLIST_ID invalide")
         return
     if not raw_spreadsheet_id:
         logging.error("Variable d'environnement SPREADSHEET_ID manquante")


### PR DESCRIPTION
## Résumé
- prise en compte de `PLAYLIST_ID` depuis un identifiant ou une URL
- documentation de `PLAYLIST_ID` comme variable d'environnement non secrète

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49e0339b08320a9d002287617aba2