### PR TITLE
Uniformisation de la clé API YouTube

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 VITE_SPREADSHEET_ID=your-spreadsheet-id
 
 # Obligatoire : clé API Google Sheets
-VITE_API_KEY=your-api-key
+VITE_YOUTUBE_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : auc
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
   (25 à 60 caractères alphanumériques, tirets ou soulignés)
-- `VITE_API_KEY` — clé API Google Sheets (ne pas réutiliser `YOUTUBE_API_KEY`)
+- `VITE_YOUTUBE_API_KEY` — clé API Google exposée côté client
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées (un modèle
 est fourni dans `.env.example`). L’application échouera au démarrage si l’une de

--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -7,9 +7,9 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
   const rows = Array.from({ length: 1201 }, () => ['value']);
 
   const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_API_KEY;
+  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
   process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_API_KEY = 'test-key';
+  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
 
   try {
     const { fetchSheetData } = await import('./fetch.ts');
@@ -30,9 +30,9 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
       process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_API_KEY;
+      delete process.env.VITE_YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_API_KEY = originalApiKey;
+      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -21,9 +21,9 @@ test('synchronizeSheets handles large sheet ranges', async () => {
   ]);
 
   const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_API_KEY;
+  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
   process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_API_KEY = 'test-key';
+  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
 
   const { synchronizeSheets } = await import('./sync.ts');
   const { SHEET_TABS } = await import('../../constants.ts');
@@ -49,9 +49,9 @@ test('synchronizeSheets handles large sheet ranges', async () => {
       process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_API_KEY;
+      delete process.env.VITE_YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_API_KEY = originalApiKey;
+      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -32,7 +32,7 @@ const rawSpreadsheetId =
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 export const API_KEY =
-  env.VITE_API_KEY ?? env.API_KEY ?? env.REACT_APP_API_KEY ?? '';
+  env.VITE_YOUTUBE_API_KEY ?? env.YOUTUBE_API_KEY ?? '';
 
 /**
  * Valide l’ID : il doit contenir au moins un caractère et ne comporter que
@@ -61,7 +61,7 @@ export function getConfig(): {
   }
   // Si la clé API est absente, on l’indique.
   if (!API_KEY) {
-    const error = 'API_KEY manquant';
+    const error = 'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }

--- a/constants.ts
+++ b/constants.ts
@@ -82,16 +82,14 @@ const rawSpreadsheetId =
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 
-// Derive the API key. When deploying via GitHub Actions, the secrets are
-// injected as environment variables without the VITE_ prefix. We therefore
-// check the common names in order of specificity. Uniquement les variables
-// dédiées à Google Sheets sont prises en compte.
-// A query parameter always overrides environment variables.
+// Derive the API key. When deploying via GitHub Actions, the secret is
+// injected as an environment variable without the VITE_ prefix. We therefore
+// check the two supported names. A query parameter always overrides
+// environment variables.
 export const API_KEY =
   apiKeyParam ||
-  env.VITE_API_KEY ||
-  env.API_KEY ||
-  env.REACT_APP_API_KEY ||
+  env.VITE_YOUTUBE_API_KEY ||
+  env.YOUTUBE_API_KEY ||
   '';
 
 /**
@@ -131,7 +129,7 @@ export function getConfig(): {
   // environment variable names to help repository owners configure secrets correctly.
   if (!API_KEY) {
     const error =
-      'API_KEY manquant : définissez VITE_API_KEY ou API_KEY, ou utilisez ?apiKey=';
+      'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY, ou utilisez ?apiKey=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }


### PR DESCRIPTION
## Résumé
- utilise uniquement `VITE_YOUTUBE_API_KEY`/`YOUTUBE_API_KEY` pour la configuration
- harmonise les messages d'erreur et les tests
- met à jour la documentation `.env` et README

## Tests
- `npm --prefix bolt-app run lint`
- `npx --prefix bolt-app eslint -c bolt-app/eslint.config.js --no-ignore constants.ts`
- `npm --prefix bolt-app test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49e067ab88320bee41a0250f96c32