### PR TITLE
Expose les secrets GitHub sans préfixe VITE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PLAYLIST_ID=your-playlist-id
 
 # Obligatoire : identifiant du Google Sheet
-VITE_SPREADSHEET_ID=your-spreadsheet-id
+SPREADSHEET_ID=your-spreadsheet-id
 
-# Obligatoire : clé API Google Sheets
-VITE_YOUTUBE_API_KEY=your-api-key
+# Obligatoire : clé API YouTube
+YOUTUBE_API_KEY=your-api-key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
-    # REND LES SECRETS VISIBLES PAR Vite (clé API + ID de la feuille)
-    # => import.meta.env.VITE_* sera injecté au build
+    # Rend les secrets disponibles pour le build Vite
     env:
-      VITE_SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
-      VITE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
-      # (facultatif, pour d’éventuels fallback côté Node/tests)
       SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
       YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
 
@@ -56,7 +52,7 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      # 5. Compile le site (Vite lira VITE_SPREADSHEET_ID / VITE_API_KEY)
+      # 5. Compile le site (Vite lira SPREADSHEET_ID / YOUTUBE_API_KEY)
       - name: Build project
         run: npm run build
         working-directory: bolt-app

--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : aucun fichier local n’est requis.
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
-- `VITE_SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
+- `SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets
   (25 à 60 caractères alphanumériques, tirets ou soulignés)
-- `VITE_YOUTUBE_API_KEY` — clé API Google exposée côté client
+- `YOUTUBE_API_KEY` — clé API Google
 
 Créer un fichier `.env` dans le dossier `bolt-app` avec ces entrées (un modèle
 est fourni dans `.env.example`). L’application échouera au démarrage si l’une de
 ces variables est absente.
 
-Seules les variables préfixées par `VITE_` sont exposées côté client ; des noms
-comme `SPREADSHEET_ID` ou `API_KEY` ne seront pas accessibles.
+Le fichier de configuration Vite expose automatiquement ces variables au
+code client : aucun préfixe `VITE_` n’est nécessaire.
 
 Pour des tests rapides, ces valeurs peuvent aussi être fournies via l’URL :
 `?spreadsheetId=` et `?apiKey=`.

--- a/bolt-app/.env.example
+++ b/bolt-app/.env.example
@@ -1,5 +1,5 @@
 # Obligatoire : identifiant du Google Sheet
-VITE_SPREADSHEET_ID=your-spreadsheet-id
+SPREADSHEET_ID=your-spreadsheet-id
 
-# Obligatoire : clé API Google Sheets
-VITE_API_KEY=your-api-key
+# Obligatoire : clé API YouTube
+YOUTUBE_API_KEY=your-api-key

--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -6,10 +6,10 @@ import assert from 'node:assert/strict';
 test('fetchSheetData retrieves all rows for unbounded range', async () => {
   const rows = Array.from({ length: 1201 }, () => ['value']);
 
-  const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
-  process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'test-id';
+  process.env.YOUTUBE_API_KEY = 'test-key';
 
   try {
     const { fetchSheetData } = await import('./fetch.ts');
@@ -25,14 +25,14 @@ test('fetchSheetData retrieves all rows for unbounded range', async () => {
   } finally {
     mock.restoreAll();
     if (originalSpreadsheetId === undefined) {
-      delete process.env.VITE_SPREADSHEET_ID;
+      delete process.env.SPREADSHEET_ID;
     } else {
-      process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
+      process.env.SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_YOUTUBE_API_KEY;
+      delete process.env.YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
+      process.env.YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -20,10 +20,10 @@ test('synchronizeSheets handles large sheet ranges', async () => {
     'https://example.com/thumb.jpg'
   ]);
 
-  const originalSpreadsheetId = process.env.VITE_SPREADSHEET_ID;
-  const originalApiKey = process.env.VITE_YOUTUBE_API_KEY;
-  process.env.VITE_SPREADSHEET_ID = 'test-id';
-  process.env.VITE_YOUTUBE_API_KEY = 'test-key';
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'test-id';
+  process.env.YOUTUBE_API_KEY = 'test-key';
 
   const { synchronizeSheets } = await import('./sync.ts');
   const { SHEET_TABS } = await import('../../constants.ts');
@@ -44,14 +44,14 @@ test('synchronizeSheets handles large sheet ranges', async () => {
     mock.restoreAll();
     SHEET_TABS.splice(0, SHEET_TABS.length, ...originalTabs);
     if (originalSpreadsheetId === undefined) {
-      delete process.env.VITE_SPREADSHEET_ID;
+      delete process.env.SPREADSHEET_ID;
     } else {
-      process.env.VITE_SPREADSHEET_ID = originalSpreadsheetId;
+      process.env.SPREADSHEET_ID = originalSpreadsheetId;
     }
     if (originalApiKey === undefined) {
-      delete process.env.VITE_YOUTUBE_API_KEY;
+      delete process.env.YOUTUBE_API_KEY;
     } else {
-      process.env.VITE_YOUTUBE_API_KEY = originalApiKey;
+      process.env.YOUTUBE_API_KEY = originalApiKey;
     }
   }
 });

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -24,15 +24,10 @@ export function parseSpreadsheetId(input: string): string {
   return id.trim();
 }
 
-const rawSpreadsheetId =
-  env.VITE_SPREADSHEET_ID ??
-  env.SPREADSHEET_ID ??
-  env.REACT_APP_SPREADSHEET_ID ??
-  '';
+const rawSpreadsheetId = env.SPREADSHEET_ID ?? '';
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
-export const API_KEY =
-  env.VITE_YOUTUBE_API_KEY ?? env.YOUTUBE_API_KEY ?? '';
+export const API_KEY = env.YOUTUBE_API_KEY ?? '';
 
 /**
  * Valide l’ID : il doit contenir au moins un caractère et ne comporter que
@@ -49,7 +44,7 @@ export function getConfig(): {
 } {
   // Si l’ID est vide, on considère qu’il est manquant et on affiche le message approprié.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant : définissez VITE_SPREADSHEET_ID';
+    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
@@ -61,7 +56,7 @@ export function getConfig(): {
   }
   // Si la clé API est absente, on l’indique.
   if (!API_KEY) {
-    const error = 'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY';
+    const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }

--- a/bolt-app/vite.config.ts
+++ b/bolt-app/vite.config.ts
@@ -1,11 +1,18 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-   base: '/youtube-to-sheets/',
-  optimizeDeps: {
-    exclude: ['lucide-react'],
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    plugins: [react()],
+    base: '/youtube-to-sheets/',
+    optimizeDeps: {
+      exclude: ['lucide-react'],
+    },
+    define: {
+      'import.meta.env': env,
+      'process.env': env,
+    },
+  };
 });

--- a/constants.ts
+++ b/constants.ts
@@ -17,10 +17,9 @@ export const SHEET_TABS: SheetTab[] = [
   { name: 'Inconnue', range: 'Inconnue!A2:M', durationRange: { min: null, max: null } }
 ];
 
-// Vite and Node both expose environment variables in different places. We
-// attempt to read from import.meta.env first (Vite), then fall back to
-// process.env (Node) for completeness. Note that only variables prefixed
-// with VITE_ are exposed to the client in a Vite build.
+// Vite et Node exposent les variables d’environnement à des endroits
+// différents. On lit d’abord `import.meta.env` (Vite), puis on se replie sur
+// `process.env` (Node).
 const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
 
 /**
@@ -65,30 +64,19 @@ function deriveConfigFromParams() {
 const { spreadsheetIdParam, apiKeyParam } = deriveConfigFromParams();
 
 // Determine the raw spreadsheet ID by preferring the query parameter over
-// environment variables. Accept both `VITE_SPREADSHEET_ID` and un-prefixed
-// versions for convenience. If nothing is provided, the string will be
-// empty and will trigger a configuration error later.
+// the environment variable. Si rien n’est fourni, la chaîne sera vide et
+// provoquera une erreur de configuration plus loin.
 const rawSpreadsheetId =
-  // Prefer the ID from the query string over any environment variable.  In
-  // production builds, only variables prefixed with VITE_ are exposed to
-  // the client, but we also support un‑prefixed names for convenience when
-  // running locally or injecting via GitHub secrets.  The SPREADSHEET_ID
-  // secret defined in this repository will be captured here.
   spreadsheetIdParam ||
-  env.VITE_SPREADSHEET_ID ||
   env.SPREADSHEET_ID ||
-  env.REACT_APP_SPREADSHEET_ID ||
   '';
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
 
-// Derive the API key. When deploying via GitHub Actions, the secret is
-// injected as an environment variable without the VITE_ prefix. We therefore
-// check the two supported names. A query parameter always overrides
-// environment variables.
+// Derive the API key. A query parameter always overrides the environment
+// variable.
 export const API_KEY =
   apiKeyParam ||
-  env.VITE_YOUTUBE_API_KEY ||
   env.YOUTUBE_API_KEY ||
   '';
 
@@ -115,7 +103,7 @@ export function getConfig(): {
 } {
   // If the ID is empty, mark it as missing.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant : définissez VITE_SPREADSHEET_ID ou utilisez ?spreadsheetId=';
+    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID ou utilisez ?spreadsheetId=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
@@ -128,8 +116,7 @@ export function getConfig(): {
   // If the API key is missing, signal it explicitly. Mention the supported
   // environment variable names to help repository owners configure secrets correctly.
   if (!API_KEY) {
-    const error =
-      'API_KEY manquant : définissez VITE_YOUTUBE_API_KEY ou YOUTUBE_API_KEY, ou utilisez ?apiKey=';
+    const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY ou utilisez ?apiKey=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }


### PR DESCRIPTION
## Résumé
- injecte toutes les variables d'environnement dans `import.meta.env`
- passe uniquement `SPREADSHEET_ID` et `YOUTUBE_API_KEY` au workflow de déploiement

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49fd80f448320888c9cd9874b0b78