### PR TITLE
Expose les secrets GitHub sans préfixe VITE

### DIFF
--- a/bolt-app/vite.config.ts
+++ b/bolt-app/vite.config.ts
@@ -1,18 +1,13 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-  return {
-    plugins: [react()],
-    base: '/youtube-to-sheets/',
-    optimizeDeps: {
-      exclude: ['lucide-react'],
-    },
-    define: {
-      'import.meta.env': env,
-      'process.env': env,
-    },
-  };
+export default defineConfig({
+  plugins: [react()],
+  base: '/youtube-to-sheets/',
+  optimizeDeps: {
+    exclude: ['lucide-react'],
+  },
+  // Only expose the required variables instead of the entire environment.
+  envPrefix: ['VITE_', 'SPREADSHEET_ID', 'YOUTUBE_API_KEY'],
 });


### PR DESCRIPTION
## Summary
- expose only SPREADSHEET_ID and YOUTUBE_API_KEY via Vite envPrefix

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bdb41a7c83209d696eabe7a02239