### PR TITLE
Accepte l'ID de playlist en argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Secrets GitHub à créer :
   (une suite de 25 à 60 caractères alphanumériques, tirets ou soulignés)
 - `SERVICE_ACCOUNT_JSON` contenu JSON du compte de service Google
 
-Variables d’environnement supplémentaires :
-- `PLAYLIST_ID` — identifiant **ou URL complète** de la playlist YouTube à synchroniser (peut être défini comme variable GitHub non secrète)
-
 Partage la feuille Google Sheets avec l’e‑mail du compte de service.
 Le script lit directement `SERVICE_ACCOUNT_JSON` depuis l’environnement : aucun fichier local n’est requis.
+
+Exécute la synchronisation avec :
+```bash
+python main.py PLAYLIST_ID [--sheet-tab-name NOM_ONGLET]
+```
 
 Variables d’environnement **obligatoires** pour l’application web `bolt-app` :
 - `SPREADSHEET_ID` — identifiant **ou URL complète** de la feuille Google Sheets

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import time
 import logging
 import json
 from datetime import datetime
+import argparse
 
 import requests
 from google.oauth2 import service_account
@@ -227,7 +228,7 @@ def add_video_to_categories(entry: list, duration_category: str, videos_by_categ
     videos_by_category[duration_category].append(entry)
     all_videos.append(entry)
 
-def sync_videos() -> None:
+def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
     """
     Récupère les vidéos d’une playlist YouTube et met à jour un Google Sheet.
     Regroupe par catégorie de durée et alimente les onglets correspondants.
@@ -235,12 +236,8 @@ def sync_videos() -> None:
     # Variables d’environnement
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     raw_spreadsheet_id = os.environ.get("SPREADSHEET_ID")
-    raw_playlist_id = os.environ.get("PLAYLIST_ID")
-    SHEET_TAB_NAME = os.environ.get("SHEET_TAB_NAME", "AllVideos")
-    if not raw_playlist_id:
-        logging.error("Variable d'environnement PLAYLIST_ID manquante")
-        return
-    playlist_source_id = parse_playlist_id(raw_playlist_id)
+    playlist_source_id = parse_playlist_id(playlist_id)
+    SHEET_TAB_NAME = sheet_tab_name
     if not playlist_source_id:
         logging.error("PLAYLIST_ID invalide")
         return
@@ -360,4 +357,8 @@ def sync_videos() -> None:
 
 
 if __name__ == "__main__":
-    sync_videos()
+    parser = argparse.ArgumentParser(description="Synchronise une playlist YouTube vers Google Sheets")
+    parser.add_argument("playlist_id", help="Identifiant ou URL de la playlist YouTube")
+    parser.add_argument("--sheet-tab-name", default="AllVideos", help="Nom de l'onglet cible dans Google Sheets")
+    args = parser.parse_args()
+    sync_videos(args.playlist_id, args.sheet_tab_name)

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -5,7 +5,6 @@ from main import sync_videos
 def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setenv("YOUTUBE_API_KEY", "key")
     monkeypatch.setenv("SPREADSHEET_ID", "A" * 25)
-    monkeypatch.setenv("PLAYLIST_ID", "PL123")
     monkeypatch.setenv("SERVICE_ACCOUNT_JSON", "{}")
 
     monkeypatch.setattr(
@@ -20,5 +19,5 @@ def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     monkeypatch.setattr("main.fetch_all_playlist_items", fake_fetch)
 
     with caplog.at_level(logging.ERROR):
-        sync_videos()
+        sync_videos("PL123")
     assert "Impossible de récupérer les vidéos de la playlist" in caplog.text


### PR DESCRIPTION
## Résumé
- remplace la variable d'environnement PLAYLIST_ID par un argument obligatoire
- ajoute un argument `--sheet-tab-name` optionnel et documente l'utilisation
- adapte les tests à la nouvelle signature

## Tests
- `flake8 main.py tests/test_sync_videos_error.py` *(échoué : flake8 non installé, proxy 403)*
- `pytest`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4bf189ccc832082fa1aa10f1b95b3