### PR TITLE
Support des paramètres d'URL et nettoyage des secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
-    # REND LES SECRETS VISIBLES PAR Vite (clé API + ID de la feuille)
-    # => import.meta.env.VITE_* sera injecté au build
+    # Expose les secrets au build (clé API + ID de la feuille)
     env:
-      VITE_SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
-      VITE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
-      # (facultatif, pour d’éventuels fallback côté Node/tests)
       SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
       YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
 
@@ -56,7 +52,7 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      # 5. Compile le site (Vite lira VITE_SPREADSHEET_ID / VITE_API_KEY)
+      # 5. Compile le site (Vite lira SPREADSHEET_ID / YOUTUBE_API_KEY)
       - name: Build project
         run: npm run build
         working-directory: bolt-app

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -24,10 +24,36 @@ export function parseSpreadsheetId(input: string): string {
   return id.trim();
 }
 
-const rawSpreadsheetId = env.SPREADSHEET_ID ?? '';
+function deriveConfigFromParams() {
+  let spreadsheetIdParam: string | null = null;
+  let apiKeyParam: string | null = null;
+
+  if (typeof window !== 'undefined' && window.location) {
+    const params = new URLSearchParams(window.location.search);
+    spreadsheetIdParam = params.get('spreadsheetId');
+    apiKeyParam = params.get('apiKey');
+  }
+
+  const parsedId = spreadsheetIdParam ? parseSpreadsheetId(spreadsheetIdParam) : '';
+  return {
+    spreadsheetIdParam: parsedId,
+    apiKeyParam: apiKeyParam ?? ''
+  };
+}
+
+const { spreadsheetIdParam, apiKeyParam } = deriveConfigFromParams();
+
+const rawSpreadsheetId =
+  spreadsheetIdParam ||
+  env.SPREADSHEET_ID ||
+  '';
 
 export const SPREADSHEET_ID = parseSpreadsheetId(rawSpreadsheetId);
-export const API_KEY = env.YOUTUBE_API_KEY ?? '';
+
+export const API_KEY =
+  apiKeyParam ||
+  env.YOUTUBE_API_KEY ||
+  '';
 
 /**
  * Valide l’ID : il doit contenir au moins un caractère et ne comporter que
@@ -44,7 +70,7 @@ export function getConfig(): {
 } {
   // Si l’ID est vide, on considère qu’il est manquant et on affiche le message approprié.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID';
+    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID ou utilisez ?spreadsheetId=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
@@ -56,7 +82,7 @@ export function getConfig(): {
   }
   // Si la clé API est absente, on l’indique.
   if (!API_KEY) {
-    const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY';
+    const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY ou utilisez ?apiKey=';
     console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }


### PR DESCRIPTION
## Résumé
- Lecture des paramètres `spreadsheetId` et `apiKey` dans l'application web avec repli sur les variables d'environnement.
- Simplification du workflow de déploiement pour n'utiliser que les secrets `SPREADSHEET_ID` et `YOUTUBE_API_KEY`.

## Tests
- `pytest`
- `npm run lint` (dans `bolt-app`)
- `npm test` (dans `bolt-app`)


------
https://chatgpt.com/codex/tasks/task_e_68b55cfdec0c8320aa816d98c99eb575