### PR TITLE
Corrige le filtrage des titres inconnus dans l'export

### DIFF
--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -64,10 +64,11 @@ for idx, sheet_range in enumerate(SHEET_RANGES):
 out_dir = pathlib.Path("bolt-app/public/data")
 out_dir.mkdir(parents=True, exist_ok=True)
 
-# Filter out rows with unknown title "Inconnu"
-ifall_values:
-header, *rows = all_values
+if all_values:
+    header, *rows = all_values
     rows = [row for row in rows if len(row) > 1 and row[1] != "Inconnu"]
+    all_values = [header] + rows
+
 # Save CSV
 
 


### PR DESCRIPTION
## Résumé
- Filtre correctement les lignes dont le titre est "Inconnu" dans `export_sheet.py` et reconstruit la liste finale.

## Tests
- `python -m py_compile scripts/export_sheet.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b592f4d310832094a5553d69ecf2c2