### PR TITLE
Fusion explicite des environnements

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -12,7 +12,10 @@ export const SHEET_TABS: SheetTab[] = [
   { name: 'Inconnue', range: 'Inconnue!A2:M', durationRange: { min: null, max: null } },
 ];
 
-const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
+const env = {
+  ...(globalThis as any).process?.env ?? {},
+  ...(import.meta as any).env ?? {},
+};
 
 /**
  * Extrait l’ID du classeur à partir d’une URL complète ou renvoie la chaîne fournie.

--- a/constants.ts
+++ b/constants.ts
@@ -20,7 +20,10 @@ export const SHEET_TABS: SheetTab[] = [
 // Vite et Node exposent les variables d’environnement à des endroits
 // différents. On lit d’abord `import.meta.env` (Vite), puis on se replie sur
 // `process.env` (Node).
-const env = (import.meta as any).env ?? (globalThis as any).process?.env ?? {};
+const env = {
+  ...(globalThis as any).process?.env ?? {},
+  ...(import.meta as any).env ?? {},
+};
 
 /**
  * Extracts the spreadsheet ID from a full Google Sheets URL. If the input


### PR DESCRIPTION
## Résumé
- fusion explicite de `process.env` et `import.meta.env` dans les constantes partagées
- garantit la lecture de `SPREADSHEET_ID` et `YOUTUBE_API_KEY` depuis l'environnement unifié

## Tests
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b597dbef988320a3164b895ac444cc