### PR TITLE
feat: handle missing spreadsheet id

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.test.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.test.ts
@@ -1,6 +1,24 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
+test('getConfig fournit un message d\'aide quand SPREADSHEET_ID est absent', async () => {
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  delete process.env.SPREADSHEET_ID;
+
+  const { getConfig } = await import(`../../constants.ts?fetch=${Date.now()}`);
+  const config = getConfig();
+
+  assert.equal(config.SPREADSHEET_ID, '');
+  assert.ok(config.help);
+  assert.ok(!('error' in config));
+
+  if (originalSpreadsheetId === undefined) {
+    delete process.env.SPREADSHEET_ID;
+  } else {
+    process.env.SPREADSHEET_ID = originalSpreadsheetId;
+  }
+});
+
 // Verify that fetchSheetData correctly handles ranges without an upper bound
 // and returns all available rows.
 test('fetchSheetData retrieves all rows for unbounded range', async () => {

--- a/bolt-app/src/utils/api/sheets/index.test.ts
+++ b/bolt-app/src/utils/api/sheets/index.test.ts
@@ -1,9 +1,14 @@
 import test, { mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchAllVideos } from './index.ts';
-import { getConfig } from '../../constants.ts';
 
 test('fetchAllVideos uses local data when config error', async () => {
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'test-id';
+  delete process.env.YOUTUBE_API_KEY;
+
+  const { fetchAllVideos } = await import(`./index.ts?index=${Date.now()}`);
+  const { getConfig } = await import(`../../constants.ts?index=${Date.now()}`);
 
   const { error } = getConfig();
   assert.ok(error, 'Test requires missing configuration');
@@ -38,5 +43,14 @@ test('fetchAllVideos uses local data when config error', async () => {
   assert.ok(result.metadata?.errors?.includes(error));
 
   mock.restoreAll();
+  if (originalSpreadsheetId === undefined) {
+    delete process.env.SPREADSHEET_ID;
+  } else {
+    process.env.SPREADSHEET_ID = originalSpreadsheetId;
+  }
+  if (originalApiKey === undefined) {
+    delete process.env.YOUTUBE_API_KEY;
+  } else {
+    process.env.YOUTUBE_API_KEY = originalApiKey;
+  }
 });
-

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -1,6 +1,24 @@
 import { test, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
+test("getConfig propose une aide si l'ID est absent", async () => {
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  delete process.env.SPREADSHEET_ID;
+
+  const { getConfig } = await import(`../../constants.ts?sync=${Date.now()}`);
+  const config = getConfig();
+
+  assert.equal(config.SPREADSHEET_ID, '');
+  assert.ok(config.help);
+  assert.ok(!('error' in config));
+
+  if (originalSpreadsheetId === undefined) {
+    delete process.env.SPREADSHEET_ID;
+  } else {
+    process.env.SPREADSHEET_ID = originalSpreadsheetId;
+  }
+});
+
 // Ensure the sheet synchronization can handle more than 1000 rows
 // by mocking the global fetch to return 1201 unique entries.
 test('synchronizeSheets handles large sheet ranges', async () => {

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -70,12 +70,19 @@ export function getConfig(): {
   SPREADSHEET_ID: string;
   API_KEY: string;
   error?: string;
+  help?: string;
 } {
-  // Si l’ID est vide, on considère qu’il est manquant et on affiche le message approprié.
+  // Si l’ID est vide, on propose une saisie utilisateur sans consigner d’erreur.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID ou utilisez ?spreadsheetId=';
-    console.error(error);
-    return { SPREADSHEET_ID: '', API_KEY: '', error };
+    let userInput = '';
+    if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
+      userInput = parseSpreadsheetId(window.prompt("Veuillez saisir l'ID du Google Sheet :") || '');
+    }
+    return {
+      SPREADSHEET_ID: userInput,
+      API_KEY,
+      help: "SPREADSHEET_ID manquant : définissez SPREADSHEET_ID, utilisez ?spreadsheetId= ou saisissez-le dans la boîte de dialogue.",
+    };
   }
   // Si l’ID n’est pas composé uniquement de caractères valides, on le signale comme invalide.
   if (!isValidSpreadsheetId(SPREADSHEET_ID)) {

--- a/constants.ts
+++ b/constants.ts
@@ -103,12 +103,19 @@ export function getConfig(): {
   SPREADSHEET_ID: string;
   API_KEY: string;
   error?: string;
+  help?: string;
 } {
-  // If the ID is empty, mark it as missing.
+  // If the ID is empty, provide a gentle hint instead of logging an error.
   if (!SPREADSHEET_ID) {
-    const error = 'SPREADSHEET_ID manquant : définissez SPREADSHEET_ID ou utilisez ?spreadsheetId=';
-    console.error(error);
-    return { SPREADSHEET_ID: '', API_KEY: '', error };
+    let userInput = '';
+    if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
+      userInput = parseSpreadsheetId(window.prompt('Veuillez saisir l\'ID du Google Sheet :') || '');
+    }
+    return {
+      SPREADSHEET_ID: userInput,
+      API_KEY,
+      help: "SPREADSHEET_ID manquant : définissez SPREADSHEET_ID, utilisez ?spreadsheetId= ou saisissez-le dans la boîte de dialogue.",
+    };
   }
   // If the ID contains characters outside the allowed set, flag it as invalid.
   if (!isValidSpreadsheetId(SPREADSHEET_ID)) {

--- a/tests/test_sync_videos_error.py
+++ b/tests/test_sync_videos_error.py
@@ -21,3 +21,14 @@ def test_sync_videos_handles_fetch_error(monkeypatch, caplog, tmp_path):
     with caplog.at_level(logging.ERROR):
         sync_videos("PL123")
     assert "Impossible de récupérer les vidéos de la playlist" in caplog.text
+
+
+def test_sync_videos_missing_spreadsheet_id(monkeypatch, caplog):
+    """Vérifie qu'un message clair est journalisé si SPREADSHEET_ID est absent."""
+    monkeypatch.setenv("YOUTUBE_API_KEY", "key")
+    monkeypatch.setenv("SERVICE_ACCOUNT_JSON", "{}")
+
+    with caplog.at_level(logging.ERROR):
+        sync_videos("PL123")
+
+    assert "Variable d'environnement SPREADSHEET_ID manquante" in caplog.text


### PR DESCRIPTION
## Summary
- ask user for spreadsheet id when missing instead of logging an error
- update tests to cover the helper message

## Testing
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b599c8c0688320a5560f24609ec91e