### PR TITLE
Supprimer les console.error dans la configuration

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -87,13 +87,11 @@ export function getConfig(): {
   // Si l’ID n’est pas composé uniquement de caractères valides, on le signale comme invalide.
   if (!isValidSpreadsheetId(SPREADSHEET_ID)) {
     const error = 'SPREADSHEET_ID invalide';
-    console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
   // Si la clé API est absente, on l’indique.
   if (!API_KEY) {
     const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY ou utilisez ?apiKey=';
-    console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
   // Retourne la configuration correcte.

--- a/constants.ts
+++ b/constants.ts
@@ -120,14 +120,12 @@ export function getConfig(): {
   // If the ID contains characters outside the allowed set, flag it as invalid.
   if (!isValidSpreadsheetId(SPREADSHEET_ID)) {
     const error = 'SPREADSHEET_ID invalide';
-    console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
   // If the API key is missing, signal it explicitly. Mention the supported
   // environment variable names to help repository owners configure secrets correctly.
   if (!API_KEY) {
     const error = 'API_KEY manquant : définissez YOUTUBE_API_KEY ou utilisez ?apiKey=';
-    console.error(error);
     return { SPREADSHEET_ID: '', API_KEY: '', error };
   }
   return { SPREADSHEET_ID, API_KEY };


### PR DESCRIPTION
## Résumé
- évite le `console.error` dans les deux `getConfig`
- retourne seulement l'objet d'erreur pour laisser l'appelant gérer l'affichage

## Tests
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59d34c9a483208167cadff3f7ab54