### PR TITLE
fix: honor workflow sheet ranges via env fallback

### DIFF
--- a/scripts/export_sheet.py
+++ b/scripts/export_sheet.py
@@ -35,13 +35,13 @@ def parse_spreadsheet_id(value: str) -> str:
 parser = argparse.ArgumentParser(description="Export specified sheet ranges to CSV and JSON")
 parser.add_argument(
     "--sheet-ranges",
-    default="AllVideos!A1:Z",
     help="Comma-separated or JSON array of sheet ranges to export",
 )
 args = parser.parse_args()
 
 SPREADSHEET_ID = parse_spreadsheet_id(os.environ["SPREADSHEET_ID"])
-SHEET_RANGES = parse_ranges(args.sheet_ranges)
+sheet_ranges_raw = args.sheet_ranges or os.environ.get("SHEET_RANGE", "AllVideos!A1:Z")
+SHEET_RANGES = parse_ranges(sheet_ranges_raw)
 for sheet_range in SHEET_RANGES:
     if "!" not in sheet_range:
         raise ValueError(


### PR DESCRIPTION
## Summary
- ensure exporter falls back to `SHEET_RANGE` env var when `--sheet-ranges` flag is absent

## Testing
- ❌ `npm test` (missing `package.json`)
- ❌ `npm run lint` (missing `package.json`)
- ✅ `python -m py_compile scripts/export_sheet.py`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a12903bc83208fc3db7a1eeb5902