### PR TITLE
Supprimer la marge par défaut du body

### DIFF
--- a/bolt-app/src/index.css
+++ b/bolt-app/src/index.css
@@ -8,7 +8,7 @@
   }
   
   body {
-    @apply bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
+    @apply m-0 bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
     touch-action: manipulation;
   }
 }


### PR DESCRIPTION
## Résumé
- ajout de la classe utilitaire `m-0` sur `body` pour supprimer la marge par défaut du navigateur

## Tests
- `npm run lint`
- `npm test` *(échoue : 2 tests sur 15)*

------
https://chatgpt.com/codex/tasks/task_e_68b71156964c832080e1b7afe0e21205