### PR TITLE
Réduire l'espace vide en haut de la page

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -114,7 +114,7 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 pt-2 pb-6">
         {configError && <MissingConfig message={configError} />}
         {!isLoading && !appError && (
           <>

--- a/bolt-app/src/index.css
+++ b/bolt-app/src/index.css
@@ -8,7 +8,7 @@
   }
   
   body {
-    @apply bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
+    @apply m-0 bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
     touch-action: manipulation;
   }
 }


### PR DESCRIPTION
## Résumé
- retrait de la marge par défaut du `body`
- réduction du padding supérieur dans la section principale pour limiter la zone grise

## Tests
- `npm run lint`
- `npm test` *(échoue : 2 tests sur 15)*

------
https://chatgpt.com/codex/tasks/task_e_68b71156964c832080e1b7afe0e21205