### PR TITLE
Réduire l'espace vide en haut de la page

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -71,7 +71,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden">
       <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-3">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pt-3 pb-1">
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">
               <button
@@ -114,7 +114,7 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 pt-1 pb-6">
         {configError && <MissingConfig message={configError} />}
         {!isLoading && !appError && (
           <>

--- a/bolt-app/src/index.css
+++ b/bolt-app/src/index.css
@@ -8,7 +8,7 @@
   }
   
   body {
-    @apply bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
+    @apply m-0 bg-neu-base dark:bg-neutral-900 overflow-x-hidden min-h-screen;
     touch-action: manipulation;
   }
 }


### PR DESCRIPTION
## Résumé
- retrait de la marge par défaut du `body`
- réduction du padding supérieur dans la section principale pour limiter la zone grise
- rapprochement de la barre de recherche du header en réduisant les paddings

## Tests
- `npm run lint`
- `npm test` *(échoue : 2 tests sur 15)*

------
https://chatgpt.com/codex/tasks/task_e_68b71156964c832080e1b7afe0e21205