### PR TITLE
Réduit l'espacement supérieur de la zone principale

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -114,7 +114,7 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 pt-2 pb-6">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 pt-1 pb-6">
         {configError && <MissingConfig message={configError} />}
         {!isLoading && !appError && (
           <>


### PR DESCRIPTION
## Résumé
- rapprocher la barre de recherche du header en réduisant le `padding-top`

## Tests
- `npm test` *(échoué : getConfig fournit un message d'aide quand SPREADSHEET_ID est absent)*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b724cb3ca4832091c4605adcfc51d4