### PR TITLE
docs: ajouter section tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,19 @@ Installation locale :
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 ```
+
+## Tests
+
+### Python
+
+```bash
+python -m pytest
+```
+
+### bolt-app
+
+```bash
+cd bolt-app && npm test
+```
+
+Ces tests n'exigent pas de secrets : les appels réseau sont simulés.


### PR DESCRIPTION
## Résumé
- ajouter une section "Tests" dans le README
- documenter `python -m pytest` pour le code Python
- documenter `cd bolt-app && npm test` pour la webapp

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68b742d4c5388320a812518206cf5499