### PR TITLE
Ajuste l’espacement du header dans Bolt

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-6">
+      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- augmente la marge inférieure du header pour plus d’espace sous le filtre

## Tests
- `npm run lint`
- `npm test` *(échec : module src/types/sheets introuvable)*
- `python -m pytest`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b81576e8748320b46a180114663de6