### PR TITLE
Supprimer l'alias API_KEY

### DIFF
--- a/bolt-app/src/utils/api/sheets/fetch.ts
+++ b/bolt-app/src/utils/api/sheets/fetch.ts
@@ -1,5 +1,5 @@
 import type { SheetResponse } from './types.ts';
-import { SPREADSHEET_ID, API_KEY } from '../../constants.ts';
+import { SPREADSHEET_ID, YOUTUBE_API_KEY } from '../../constants.ts';
 
 const RATE_LIMIT = {
   requests: 0,
@@ -79,7 +79,7 @@ export async function fetchSheetData(range: string): Promise<SheetResponse> {
 
     // Properly encode the range parameter
     const encodedRange = encodeURIComponent(range);
-    const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values/${encodedRange}?key=${API_KEY}`;
+    const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values/${encodedRange}?key=${YOUTUBE_API_KEY}`;
     
     const response = await fetchWithRetry(url);
     const data = await response.json();

--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { SheetTab } from '../types/sheets';
+import type { SheetTab } from '../types/sheets.ts';
 
 /**
  * Tabs used to group videos by duration.
@@ -97,8 +97,6 @@ function getEnvVar(key: string): string {
  */
 export const SPREADSHEET_ID: string = getEnvVar('SPREADSHEET_ID');
 export const YOUTUBE_API_KEY: string = getEnvVar('YOUTUBE_API_KEY');
-/** Backwards-compatible alias used in fetch.ts */
-export const API_KEY: string = YOUTUBE_API_KEY;
 
 /**
  * Structure returned by getConfig() describing the current configuration.


### PR DESCRIPTION
## Résumé
- remplace l'utilisation de `API_KEY` par `YOUTUBE_API_KEY` dans l'appel à l'API Sheets
- supprime l'export `API_KEY` devenu redondant dans les constantes et ajuste l'import de `SheetTab`

## Tests
- `npm run lint`
- `npm test`
- `SPREADSHEET_ID=dummy YOUTUBE_API_KEY=dummy npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b81678c2d08320aab7f75d5ed68f16