### PR TITLE
Augmente l'espacement entre les sections de filtres

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-6">
+      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">

--- a/bolt-app/src/components/DurationTabs.tsx
+++ b/bolt-app/src/components/DurationTabs.tsx
@@ -30,7 +30,7 @@ export function DurationTabs({ selectedTab, onTabChange, videos }: DurationTabsP
   }, [videos]);
 
   return (
-    <div className="mb-6">
+    <div className="mb-8">
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
         <div className="flex col-span-2 sm:col-span-1">
           <button

--- a/bolt-app/src/components/SearchBar.tsx
+++ b/bolt-app/src/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
   }, []);
 
   return (
-    <div className="mb-6">
+    <div className="mb-8">
       <div className="relative max-w-[640px] mx-auto flex items-center gap-4">
         {/* Form container with Liquid Glass styling */}
         <form


### PR DESCRIPTION
## Résumé
- élargit les marges inférieures de la barre de recherche et des onglets de durée pour créer plus d'espace entre les filtres

## Tests
- `npm run lint`
- `npm test` *(échoue : module `src/types/sheets` introuvable)*
- `python -m pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b81576e8748320b46a180114663de6