### PR TITLE
Augmente la marge basse de l'en-tête

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-6">
+      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-8">
         {/* Réduction de la hauteur d’en-tête */}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
           {/* Réduction de l’espacement vertical */}


### PR DESCRIPTION
## Résumé
- augmente la marge inférieure de l'en-tête pour un meilleur espacement

## Tests
- `npm run lint`
- `npm test`
- `python -m pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b81b9562448320a33f6a8ec2279ed8