### PR TITLE
Agrandit l'espacement sous l'en-tête

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-6">
+        <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-12">
         {/* Réduction de la hauteur d’en-tête */}
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
           {/* Réduction de l’espacement vertical */}

--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-8">
+      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- augmente la marge inférieure de l'en-tête à 48 px (mb-12)
- aligne les deux versions d'App.tsx sur le même espacement

## Tests
- `npm --prefix bolt-app run lint`
- `npm --prefix bolt-app test`
- `python -m pytest`
- `npm --prefix bolt-app run build`


------
https://chatgpt.com/codex/tasks/task_e_68b81b9562448320a33f6a8ec2279ed8