### PR TITLE
Ajuste le padding vertical de l'en-tête

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -71,7 +71,7 @@ export default function App() {
     <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
       <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-12">
         {/* Réduction de la hauteur d’en-tête */}
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-1">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
           {/* Réduction de l’espacement vertical */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- augmente le padding vertical de l'en-tête principal

## Tests
- `npm --prefix bolt-app run lint`
- `npm --prefix bolt-app test`
- `python -m pytest`
- `npm --prefix bolt-app run build`


------
https://chatgpt.com/codex/tasks/task_e_68b82424b23c8320bb21c91fb0eddca7