### PR TITLE
Amélioration du contraste du placeholder de recherche

### DIFF
--- a/bolt-app/src/components/SearchBar.tsx
+++ b/bolt-app/src/components/SearchBar.tsx
@@ -88,7 +88,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
               placeholder="Rechercher"
               value={filters.query}
               onChange={(e) => onFiltersChange({ ...filters, query: e.target.value })}
-              className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-light dark:placeholder-gray-400 text-sm focus:outline-none"
+              className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-dark dark:placeholder-gray-400 text-sm focus:outline-none"
             />
             {filters.query && (
               <button


### PR DESCRIPTION
## Résumé
- assombrit le placeholder de la barre de recherche pour un meilleur contraste en mode clair

## Tests
- `npm run lint`
- `npm test`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b826eb7944832083fb8861ff5f74b4