### PR TITLE
Améliorations visuelles de la barre de recherche

### DIFF
--- a/bolt-app/src/components/SearchBar.tsx
+++ b/bolt-app/src/components/SearchBar.tsx
@@ -79,7 +79,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
         {/* Form container with Liquid Glass styling */}
         <form
           onSubmit={handleSubmit}
-          className="flex-1 flex items-center group backdrop-blur-md bg-white/30 dark:bg-neutral-600/30 border border-white/40 dark:border-neutral-500/40 rounded-full"
+          className="flex-1 flex items-center group backdrop-blur-md bg-white/30 dark:bg-neutral-600/30 border-[1.5px] border-youtube-border dark:border-neutral-600 rounded-full transition-all duration-200 focus-within:border-youtube-red focus-within:ring-1 focus-within:ring-youtube-red focus-within:ring-opacity-50 focus-within:shadow-[0_0_10px_rgba(255,0,0,0.3)]"
         >
           <div className="relative flex-1">
             <input
@@ -88,7 +88,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
               placeholder="Rechercher"
               value={filters.query}
               onChange={(e) => onFiltersChange({ ...filters, query: e.target.value })}
-              className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-light dark:placeholder-gray-400 text-sm focus:outline-none"
+              className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-dark dark:placeholder-gray-400 text-sm focus:outline-none"
             />
             {filters.query && (
               <button


### PR DESCRIPTION
## Résumé
- harmonise la bordure du champ de recherche avec celle du bouton de soumission
- assombrit le placeholder de la barre de recherche pour un meilleur contraste en mode clair

## Tests
- `npm run lint`
- `npm test`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b826eb7944832083fb8861ff5f74b4