### PR TITLE
feat: add category sort dropdown

### DIFF
--- a/bolt-app/src/components/CategorySelect.tsx
+++ b/bolt-app/src/components/CategorySelect.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { ArrowUpDown } from 'lucide-react';
 import { VideoData } from '../types/video';
+import { DropdownMenu } from './ui/DropdownMenu';
 import { DropdownItem } from './ui/DropdownItem';
 
 interface CategorySelectProps {
@@ -11,6 +13,7 @@ interface CategorySelectProps {
 
 export function CategorySelect({ videos, selectedCategory, onCategoryChange, className = '' }: CategorySelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('desc');
 
   const categories = React.useMemo(() => {
     const uniqueCategories = new Set(
@@ -18,33 +21,35 @@ export function CategorySelect({ videos, selectedCategory, onCategoryChange, cla
         .map(video => video.category)
         .filter(category => category && category.trim() !== '')
     );
-    return Array.from(uniqueCategories).sort();
-  }, [videos]);
+    return Array.from(uniqueCategories).sort((a, b) =>
+      sortOrder === 'asc' ? a.localeCompare(b) : b.localeCompare(a)
+    );
+  }, [videos, sortOrder]);
 
   if (categories.length === 0) return null;
 
   return (
-    <div className={`relative ${className}`}>
-      {isOpen && (
-        <div className="absolute z-50 mt-2 w-full">
-          <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
-            <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
-              {categories.map(category => (
-                <DropdownItem
-                  key={category}
-                  onClick={() => {
-                    onCategoryChange(category);
-                    setIsOpen(false);
-                  }}
-                  isSelected={selectedCategory === category}
-                >
-                  {category}
-                </DropdownItem>
-              ))}
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+    <DropdownMenu
+      icon={<ArrowUpDown className="w-5 h-5 text-gray-500 group-hover:text-youtube-red transition-colors shrink-0" />}
+      label={sortOrder === 'asc' ? 'Plus anciennes' : 'Plus récentes'}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      className={className}
+    >
+      <DropdownItem onClick={() => setSortOrder('desc')}>Plus récentes</DropdownItem>
+      <DropdownItem onClick={() => setSortOrder('asc')}>Plus anciennes</DropdownItem>
+      {categories.map(category => (
+        <DropdownItem
+          key={category}
+          onClick={() => {
+            onCategoryChange(category);
+            setIsOpen(false);
+          }}
+          isSelected={selectedCategory === category}
+        >
+          {category}
+        </DropdownItem>
+      ))}
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Summary
- add sort order state and sorting logic to CategorySelect
- replace container with DropdownMenu and ArrowUpDown icon

## Testing
- `npm run lint`
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8aacdb8f48320aa3972e3834be0d0