### PR TITLE
Utilise myCategory pour le filtre de catégories

### DIFF
--- a/bolt-app/src/components/CategorySelect.tsx
+++ b/bolt-app/src/components/CategorySelect.tsx
@@ -3,6 +3,7 @@ import { ArrowUpDown } from 'lucide-react';
 import { VideoData } from '../types/video';
 import { DropdownMenu } from './ui/DropdownMenu';
 import { DropdownItem } from './ui/DropdownItem';
+import { getUniqueCategories } from '../utils/getUniqueCategories';
 
 interface CategorySelectProps {
   videos: VideoData[];
@@ -15,16 +16,10 @@ export function CategorySelect({ videos, selectedCategory, onCategoryChange, cla
   const [isOpen, setIsOpen] = React.useState(false);
   const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('desc');
 
-  const categories = React.useMemo(() => {
-    const uniqueCategories = new Set(
-      videos
-        .map(video => video.category)
-        .filter(category => category && category.trim() !== '')
-    );
-    return Array.from(uniqueCategories).sort((a, b) =>
-      sortOrder === 'asc' ? a.localeCompare(b) : b.localeCompare(a)
-    );
-  }, [videos, sortOrder]);
+  const categories = React.useMemo(
+    () => getUniqueCategories(videos, sortOrder),
+    [videos, sortOrder]
+  );
 
   if (categories.length === 0) return null;
 

--- a/bolt-app/src/utils/getUniqueCategories.test.ts
+++ b/bolt-app/src/utils/getUniqueCategories.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getUniqueCategories } from './getUniqueCategories.ts';
+
+test('getUniqueCategories utilise myCategory et trie correctement', () => {
+  const videos = [
+    { myCategory: 'Alpha' },
+    { myCategory: 'Beta' },
+    { myCategory: 'Alpha' },
+    { myCategory: '' },
+    {}
+  ];
+  assert.deepEqual(getUniqueCategories(videos as any, 'asc'), ['Alpha', 'Beta']);
+  assert.deepEqual(getUniqueCategories(videos as any, 'desc'), ['Beta', 'Alpha']);
+});

--- a/bolt-app/src/utils/getUniqueCategories.ts
+++ b/bolt-app/src/utils/getUniqueCategories.ts
@@ -1,0 +1,15 @@
+import type { VideoData } from '../types/video.ts';
+
+export function getUniqueCategories(
+  videos: VideoData[],
+  sortOrder: 'asc' | 'desc'
+): string[] {
+  const uniqueCategories = new Set(
+    videos
+      .map(video => video.myCategory)
+      .filter(category => category && category.trim() !== '')
+  );
+  return Array.from(uniqueCategories).sort((a, b) =>
+    sortOrder === 'asc' ? a.localeCompare(b) : b.localeCompare(a)
+  );
+}


### PR DESCRIPTION
## Résumé
- remplace `video.category` par `video.myCategory` via un utilitaire `getUniqueCategories`
- ajoute un test vérifiant l'extraction et le tri des catégories personnalisées

## Tests
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b08e53388320956e637abb342d83