### PR TITLE
feat: add category filter and search

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -4,6 +4,7 @@ import { VideoGrid } from './components/VideoGrid';
 import { DurationTabs } from './components/DurationTabs';
 import { SearchBar } from './components/SearchBar';
 import { SortSelect } from './components/SortSelect';
+import { CategorySelect } from './components/CategorySelect';
 import { LoadingState } from './components/LoadingState';
 import { ErrorState } from './components/ErrorState';
 import { MissingConfig } from './components/MissingConfig';
@@ -31,6 +32,7 @@ export default function App() {
     query: '',
     fields: ['title', 'channel', 'category']
   });
+  const [selectedCategory, setSelectedCategory] = React.useState<string | null>(null);
 
   const resetFilters = React.useCallback(async () => {
     playClick();
@@ -39,6 +41,7 @@ export default function App() {
       query: '',
       fields: ['title', 'channel', 'category']
     });
+    setSelectedCategory(null);
     await loadVideos();
   }, [loadVideos, playClick]);
 
@@ -63,6 +66,14 @@ export default function App() {
   const sortedVideos = React.useMemo(
     () => sortVideos(filteredByDuration, sortOptions),
     [filteredByDuration, sortOptions]
+  );
+
+  const filteredByCategory = React.useMemo(
+    () =>
+      selectedCategory
+        ? sortedVideos.filter(v => v.myCategory === selectedCategory)
+        : sortedVideos,
+    [sortedVideos, selectedCategory]
   );
 
   const appError = videosError;
@@ -106,6 +117,12 @@ export default function App() {
                     onOptionsChange={setSortOptions}
                   />
                 </div>
+                <CategorySelect
+                  videos={videos}
+                  selectedCategory={selectedCategory}
+                  onCategoryChange={setSelectedCategory}
+                  className="w-full max-w-[280px]"
+                />
               </div>
             )}
           </div>
@@ -129,7 +146,7 @@ export default function App() {
         )}
         {isLoading && <LoadingState />}
         {appError && <ErrorState message={appError} />}
-        {!isLoading && !appError && <VideoGrid videos={sortedVideos} />}
+        {!isLoading && !appError && <VideoGrid videos={filteredByCategory} />}
       </main>
     </div>
   );

--- a/bolt-app/src/utils/searchUtils.test.ts
+++ b/bolt-app/src/utils/searchUtils.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterVideosBySearch } from './searchUtils.ts';
+
+// Test ensures search on category uses myCategory field
+
+test('filterVideosBySearch utilise myCategory pour le champ category', () => {
+  const videos = [
+    { title: 'Video1', myCategory: 'News' },
+    { title: 'Video2', myCategory: 'Sport' },
+  ] as any;
+  const filters = { query: 'sport', fields: ['category'] } as const;
+  const result = filterVideosBySearch(videos, filters);
+  assert.deepEqual(result, [videos[1]]);
+});

--- a/bolt-app/src/utils/searchUtils.ts
+++ b/bolt-app/src/utils/searchUtils.ts
@@ -1,5 +1,5 @@
-import { VideoData } from '../types/video';
-import { SearchFilters } from '../types/search';
+import type { VideoData } from '../types/video.ts';
+import type { SearchFilters } from '../types/search.ts';
 
 export function filterVideosBySearch(videos: VideoData[], filters: SearchFilters): VideoData[] {
   if (!filters.query.trim() || filters.fields.length === 0) {
@@ -10,7 +10,8 @@ export function filterVideosBySearch(videos: VideoData[], filters: SearchFilters
   
   return videos.filter(video => {
     return filters.fields.some(field => {
-      const value = (video[field] ?? '').toLowerCase();
+      const key = field === 'category' ? 'myCategory' : field;
+      const value = (video[key as keyof VideoData] ?? '').toLowerCase();
       return value.includes(searchTerm);
     });
   });


### PR DESCRIPTION
## Summary
- integrate CategorySelect to filter videos by custom categories
- use myCategory for text search and add unit test

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa2bda4083208017487fe1637694