### PR TITLE
ci: export des données publiques dans la synchronisation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -99,6 +99,17 @@ jobs:
         run: python main.py "$PLAYLIST_ID"
       - name: Export sheet to JSON
         run: python export_data.py
+      - name: Export sheet to public data
+        env:
+          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
+          SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+        run: >-
+          python scripts/export_sheet.py --sheet-range "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z"
+      - name: Commit public data
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add bolt-app/public/data/videos.csv bolt-app/public/data/videos.json && git commit -m "Update public data" || true
       - name: Commit updated data
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Résumé
- ajoute l'export des plages de feuilles vers les fichiers publics CSV/JSON
- commite les fichiers `bolt-app/public/data` générés par le workflow de synchronisation
- remplace `secrets.GITHUB_TOKEN` par le jeton intégré pour le déploiement

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b999c0cbdc8320915ced7327b73032