### PR TITLE
chore: specify sheet range when exporting

### DIFF
--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -54,7 +54,7 @@ jobs:
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
           SHEET_RANGE: "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z"
-        run: python scripts/export_sheet.py
+        run: python scripts/export_sheet.py --sheet-range "$SHEET_RANGE"
 
       - name: Commit & push CSV and JSON update
         run: |


### PR DESCRIPTION
## Summary
- call `export_sheet.py` with explicit `--sheet-range`

## Testing
- `pytest` *(fails: assert "Variable d'environnement SPREADSHEET_ID manquante" in 'ERROR    root:main.py:329 SPREADSHEET_ID invalide\n')*
- `yamllint .github/workflows/export-sheets.yml` *(command not found)*
- `python scripts/export_sheet.py --sheet-range "'0-5min'!A1:Z"` *(fails: SPREADSHEET_ID invalide)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ad5b19c8320bc2dfa7dd39549ed