### PR TITLE
ci: handle no-op public data commit

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add bolt-app/public/data/videos.csv bolt-app/public/data/videos.json && git commit -m "Update public data" || true
+          git add bolt-app/public/data/videos.csv bolt-app/public/data/videos.json
+          git commit -m "Update public data" || echo "rien à valider"
       - name: Commit updated data
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- avoid failing sync workflow when public data hasn't changed by echoing a message instead

## Testing
- `pytest -q`
- `act workflow_dispatch -W .github/workflows/sync.yml || true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f2678d408320b7c6a23b72a16f55