### PR TITLE
Encadrer les noms des onglets et corriger getUniqueCategories

### DIFF
--- a/bolt-app/src/utils/constants.ts
+++ b/bolt-app/src/utils/constants.ts
@@ -8,42 +8,42 @@ import type { SheetTab } from '../types/sheets.ts';
 export const SHEET_TABS: SheetTab[] = [
   {
     name: '0-5 min',
-    range: '0-5min!A:Z',
+    range: "'0-5min'!A:Z",
     durationRange: { min: 0, max: 5 },
   },
   {
     name: '5-10 min',
-    range: '5-10min!A:Z',
+    range: "'5-10min'!A:Z",
     durationRange: { min: 5, max: 10 },
   },
   {
     name: '10-20 min',
-    range: '10-20min!A:Z',
+    range: "'10-20min'!A:Z",
     durationRange: { min: 10, max: 20 },
   },
   {
     name: '20-30 min',
-    range: '20-30min!A:Z',
+    range: "'20-30min'!A:Z",
     durationRange: { min: 20, max: 30 },
   },
   {
     name: '30-40 min',
-    range: '30-40min!A:Z',
+    range: "'30-40min'!A:Z",
     durationRange: { min: 30, max: 40 },
   },
   {
     name: '40-50 min',
-    range: '40-50min!A:Z',
+    range: "'40-50min'!A:Z",
     durationRange: { min: 40, max: 50 },
   },
   {
     name: '50-60 min',
-    range: '50-60min!A:Z',
+    range: "'50-60min'!A:Z",
     durationRange: { min: 50, max: 60 },
   },
   {
     name: '60+ min',
-    range: '60Plusmin!A:Z',
+    range: "'60Plusmin'!A:Z",
     durationRange: { min: 60, max: null },
   },
 ];

--- a/bolt-app/src/utils/getUniqueCategories.ts
+++ b/bolt-app/src/utils/getUniqueCategories.ts
@@ -1,4 +1,4 @@
-import { channelCategories } from './channelCategories';
+import { channelCategories } from './channelCategories.ts';
 import type { VideoData } from '../types/video.ts';
 
 /**
@@ -11,7 +11,10 @@ import type { VideoData } from '../types/video.ts';
  * @param videos  An array of video objects.
  * @returns      An alphabetically sorted array of unique category names.
  */
-export function getUniqueCategories(videos: VideoData[]): string[] {
+export function getUniqueCategories(
+  videos: VideoData[],
+  order: 'asc' | 'desc' = 'asc',
+): string[] {
   const uniqueCategories = new Set<string>();
   videos.forEach((video) => {
     let cat: string | undefined | null = (video as any).myCategory ?? (video as any).category;
@@ -27,5 +30,7 @@ export function getUniqueCategories(videos: VideoData[]): string[] {
       uniqueCategories.add(cat);
     }
   });
-  return Array.from(uniqueCategories).sort((a, b) => a.localeCompare(b));
+  return Array.from(uniqueCategories).sort((a, b) =>
+    order === 'desc' ? b.localeCompare(a) : a.localeCompare(b),
+  );
 }


### PR DESCRIPTION
## Résumé
- Encadrement des noms d’onglets par des guillemets simples dans les plages Google Sheets.
- Correction de getUniqueCategories : import explicite et tri configurable asc/desc.
- Vérification qu’aucune autre variable d’environnement sensible n’est utilisée.

## Tests
- `npm run lint`
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f691e7c48320a0e7c8f4a5d6cad1