### PR TITLE
Utiliser les vidéos locales en cas d'erreur Sheets

### DIFF
--- a/bolt-app/src/utils/api/sheets/index.ts
+++ b/bolt-app/src/utils/api/sheets/index.ts
@@ -47,11 +47,20 @@ export async function fetchAllVideos(): Promise<ApiResponse<VideoData[]>> {
     };
   } catch (error) {
     console.error('Error fetching videos:', error);
+    const localResponse = await fetchLocalVideos();
+
+    if (localResponse.error) {
+      throw new Error(localResponse.error);
+    }
+
     return {
-      data: [],
-      error: 'Une erreur est survenue lors de la récupération des données',
+      ...localResponse,
       metadata: {
-        errors: [error instanceof Error ? error.message : 'Erreur inconnue'],
+        ...(localResponse.metadata ?? {}),
+        errors: [
+          ...(localResponse.metadata?.errors ?? []),
+          error instanceof Error ? error.message : 'Erreur inconnue'
+        ],
         timestamp: Date.now()
       }
     };


### PR DESCRIPTION
## Résumé
- Utilise les vidéos locales comme repli lorsque la synchronisation Google Sheets échoue
- Propage une erreur seulement si la lecture locale est elle-même en échec

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9f8e073d48320904a5a8a261d9d8c