### PR TITLE
feat: étendre l'export de feuilles

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -104,7 +104,7 @@ jobs:
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
         run: >-
-          python scripts/export_sheet.py --sheet-range "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z"
+          python scripts/export_sheet.py --sheet-range "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z, '30-40min'!A1:Z, '40-50min'!A1:Z, '50-60min'!A1:Z, '60Plusmin'!A1:Z"
       - name: Commit public data
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
## Résumé
- étend la plage de feuilles exportées dans le workflow de synchronisation

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9facb98748320bd48c533f1cd9e0e