### PR TITLE
ci: include all duration tabs in export workflow

### DIFF
--- a/.github/workflows/export-sheets.yml
+++ b/.github/workflows/export-sheets.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
           SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-          SHEET_RANGE: "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z"
+          SHEET_RANGE: "'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z, '30-40min'!A1:Z, '40-50min'!A1:Z, '50-60min'!A1:Z, '60Plusmin'!A1:Z"
         run: python scripts/export_sheet.py --sheet-range "$SHEET_RANGE"
 
       - name: Commit & push CSV and JSON update


### PR DESCRIPTION
## Summary
- expand `SHEET_RANGE` in export workflow to cover all eight duration tabs

## Testing
- `pytest -q`
- `npm run lint` (bolt-app)
- `npm test` (bolt-app)
- `SHEET_RANGE="'0-5min'!A1:Z, '5-10min'!A1:Z, '10-20min'!A1:Z, '20-30min'!A1:Z, '30-40min'!A1:Z, '40-50min'!A1:Z, '50-60min'!A1:Z, '60Plusmin'!A1:Z" SPREADSHEET_ID=dummy SERVICE_ACCOUNT_JSON='{}' python scripts/export_sheet.py --sheet-range "$SHEET_RANGE"` *(fails: ValueError: SPREADSHEET_ID invalide)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fbf0e8748320a047a57cb757ff39