### PR TITLE
Charger les vidéos locales avant la synchronisation

### DIFF
--- a/bolt-app/src/utils/api/sheets/index.test.ts
+++ b/bolt-app/src/utils/api/sheets/index.test.ts
@@ -54,3 +54,146 @@ test('fetchAllVideos uses local data when config error', async () => {
     process.env.YOUTUBE_API_KEY = originalApiKey;
   }
 });
+
+test('fetchAllVideos returns synchronized data on success', async () => {
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'a'.repeat(44);
+  process.env.YOUTUBE_API_KEY = 'test-key';
+
+  const { SHEET_TABS } = await import('../../constants.ts');
+  const originalTabs = SHEET_TABS.map(tab => ({ ...tab }));
+  SHEET_TABS.length = 1;
+  SHEET_TABS[0].range = 'tab!A2:M';
+
+  const calls: string[] = [];
+  const localRows = [
+    [],
+    [
+      '',
+      'Local',
+      'https://www.youtube.com/watch?v=local',
+      'Channel',
+      '2020-01-01T00:00:00Z',
+      'PT10M',
+      '0',
+      '0',
+      '0',
+      '',
+      '',
+      '',
+      ''
+    ]
+  ];
+  const remoteRows = [
+    [
+      '',
+      'Remote',
+      'https://www.youtube.com/watch?v=remote',
+      'Channel',
+      '2020-01-02T00:00:00Z',
+      'PT10M',
+      '0',
+      '0',
+      '0',
+      '',
+      '',
+      '',
+      ''
+    ]
+  ];
+
+  const fetchMock = mock.method(globalThis, 'fetch', async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('data/videos.json')) {
+      calls.push('local');
+      return new Response(JSON.stringify(localRows), { status: 200 });
+    }
+    calls.push('sync');
+    return new Response(JSON.stringify({ values: remoteRows }), { status: 200 });
+  });
+
+  const { fetchAllVideos } = await import(`./index.ts?success=${Date.now()}`);
+  const result = await fetchAllVideos();
+
+  assert.deepEqual(calls, ['local', 'sync']);
+  assert.equal(result.data?.[0].title, 'Remote');
+
+  mock.restoreAll();
+  SHEET_TABS.splice(0, SHEET_TABS.length, ...originalTabs);
+  if (originalSpreadsheetId === undefined) {
+    delete process.env.SPREADSHEET_ID;
+  } else {
+    process.env.SPREADSHEET_ID = originalSpreadsheetId;
+  }
+  if (originalApiKey === undefined) {
+    delete process.env.YOUTUBE_API_KEY;
+  } else {
+    process.env.YOUTUBE_API_KEY = originalApiKey;
+  }
+});
+
+test('fetchAllVideos keeps local data when synchronization fails', async () => {
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'a'.repeat(44);
+  process.env.YOUTUBE_API_KEY = 'test-key';
+
+  const { SHEET_TABS } = await import('../../constants.ts');
+  const originalTabs = SHEET_TABS.map(tab => ({ ...tab }));
+  SHEET_TABS.length = 1;
+  SHEET_TABS[0].range = 'tab!A2:M';
+
+  const calls: string[] = [];
+  const localRows = [
+    [],
+    [
+      '',
+      'Local',
+      'https://www.youtube.com/watch?v=local',
+      'Channel',
+      '2020-01-01T00:00:00Z',
+      'PT10M',
+      '0',
+      '0',
+      '0',
+      '',
+      '',
+      '',
+      ''
+    ]
+  ];
+
+  const fetchMock = mock.method(globalThis, 'fetch', async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('data/videos.json')) {
+      calls.push('local');
+      return new Response(JSON.stringify(localRows), { status: 200 });
+    }
+    calls.push('sync');
+    return new Response(JSON.stringify({ values: [] }), { status: 200 });
+  });
+
+  const consoleError = mock.method(console, 'error', () => {});
+
+  const { fetchAllVideos } = await import(`./index.ts?failure=${Date.now()}`);
+  const result = await fetchAllVideos();
+
+  assert.deepEqual(calls, ['local', 'sync']);
+  assert.equal(result.data?.[0].title, 'Local');
+  assert.ok(result.metadata?.errors?.length);
+  assert.ok(consoleError.mock.calls.length >= 1);
+
+  mock.restoreAll();
+  SHEET_TABS.splice(0, SHEET_TABS.length, ...originalTabs);
+  if (originalSpreadsheetId === undefined) {
+    delete process.env.SPREADSHEET_ID;
+  } else {
+    process.env.SPREADSHEET_ID = originalSpreadsheetId;
+  }
+  if (originalApiKey === undefined) {
+    delete process.env.YOUTUBE_API_KEY;
+  } else {
+    process.env.YOUTUBE_API_KEY = originalApiKey;
+  }
+});

--- a/bolt-app/src/utils/api/sheets/index.ts
+++ b/bolt-app/src/utils/api/sheets/index.ts
@@ -14,12 +14,12 @@ export { fetchLocalVideos };
  * - Sinon, on tente de synchroniser avec Google Sheets.
  */
 export async function fetchAllVideos(): Promise<ApiResponse<VideoData[]>> {
+  const localResponse = await fetchLocalVideos();
   const config = getConfig();
 
   // Si une erreur est détectée ou si un message d'aide est présent,
   // on se rabat sur les données locales au lieu d'interroger les API externes.
   if (config.error || config.help) {
-    const localResponse = await fetchLocalVideos();
     return {
       ...localResponse,
       // On conserve l'erreur d'origine seulement si elle existe ; sinon, on garde l'erreur locale
@@ -47,7 +47,6 @@ export async function fetchAllVideos(): Promise<ApiResponse<VideoData[]>> {
     };
   } catch (error) {
     console.error('Error fetching videos:', error);
-    const localResponse = await fetchLocalVideos();
 
     if (localResponse.error) {
       throw new Error(localResponse.error);


### PR DESCRIPTION
## Résumé
- Charge d'abord les vidéos locales puis tente la synchronisation Sheets.
- Conserve les données locales en cas d'échec tout en journalisant l'erreur.
- Ajoute des tests couvrant la réussite et l'échec de la synchronisation.

## Tests
- `npm --prefix bolt-app test`
- `npm --prefix bolt-app run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fe5615e48320afbf6fd9c9736e50