### PR TITLE
Filtrer les vidéos par catégorie avant la durée

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -55,25 +55,25 @@ export default function App() {
     [videos, searchFilters]
   );
 
+  const filteredByCategory = React.useMemo(
+    () =>
+      selectedCategory
+        ? filteredBySearch.filter(v => v.myCategory === selectedCategory)
+        : filteredBySearch,
+    [filteredBySearch, selectedCategory]
+  );
+
   const filteredByDuration = React.useMemo(
     () =>
       selectedTab === -1
-        ? filteredBySearch
-        : filterVideosByDuration(filteredBySearch, SHEET_TABS[selectedTab]),
-    [filteredBySearch, selectedTab]
+        ? filteredByCategory
+        : filterVideosByDuration(filteredByCategory, SHEET_TABS[selectedTab]),
+    [filteredByCategory, selectedTab]
   );
 
   const sortedVideos = React.useMemo(
     () => sortVideos(filteredByDuration, sortOptions),
     [filteredByDuration, sortOptions]
-  );
-
-  const filteredByCategory = React.useMemo(
-    () =>
-      selectedCategory
-        ? sortedVideos.filter(v => v.myCategory === selectedCategory)
-        : sortedVideos,
-    [sortedVideos, selectedCategory]
   );
 
   const appError = videosError;
@@ -140,13 +140,13 @@ export default function App() {
             <DurationTabs
               selectedTab={selectedTab}
               onTabChange={setSelectedTab}
-              videos={filteredBySearch}
+              videos={filteredByCategory}
             />
           </>
         )}
         {isLoading && <LoadingState />}
         {appError && <ErrorState message={appError} />}
-        {!isLoading && !appError && <VideoGrid videos={filteredByCategory} />}
+        {!isLoading && !appError && <VideoGrid videos={sortedVideos} />}
       </main>
     </div>
   );


### PR DESCRIPTION
## Résumé
- Applique le filtre de catégorie immédiatement après la recherche et avant la durée
- Passe le résultat filtré par catégorie aux onglets de durée
- Affiche la grille vidéo à partir de la liste triée finale

## Tests
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba08b1663c83208ab78b3217cb52b9