### PR TITLE
Désactivation du cache pour les vidéos locales

### DIFF
--- a/bolt-app/src/utils/api/sheets/local.test.ts
+++ b/bolt-app/src/utils/api/sheets/local.test.ts
@@ -1,0 +1,20 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Verify that fetchLocalVideos disables caching and adds a unique version parameter
+// to the request URL.
+test('fetchLocalVideos ajoute un paramètre de version et utilise cache "no-store"', async () => {
+  const fetchMock = mock.method(globalThis, 'fetch', async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.url;
+    assert.ok(/data\/videos\.json\?t=\d+/.test(url));
+    assert.equal(init?.cache, 'no-store');
+    return new Response(JSON.stringify([[]]), { status: 200 });
+  });
+
+  const { fetchLocalVideos } = await import(`./local.ts?test=${Date.now()}`);
+
+  await fetchLocalVideos();
+  assert.equal(fetchMock.mock.calls.length, 1);
+
+  mock.restoreAll();
+});

--- a/bolt-app/src/utils/api/sheets/local.ts
+++ b/bolt-app/src/utils/api/sheets/local.ts
@@ -5,8 +5,9 @@ import { mapRowToVideo } from './transform.ts';
 
 export async function fetchLocalVideos(): Promise<ApiResponse<VideoData[]>> {
   try {
-const baseUrl = (import.meta as any).env?.BASE_URL ?? '';
-    const res = await fetch(`${baseUrl}data/videos.json`);    
+    const baseUrl = (import.meta as any).env?.BASE_URL ?? '';
+    const url = `${baseUrl}data/videos.json?t=${Date.now()}`;
+    const res = await fetch(url, { cache: 'no-store' });
     const json = await res.json();
     const [, ...rows] = json as any[][]; // skip header row
     const videos = rows


### PR DESCRIPTION
## Résumé
- empêche la mise en cache en ajoutant un paramètre unique à l’URL des vidéos locales
- force l’option `cache: 'no-store'` lors de la récupération des vidéos locales
- vérifie via un test unitaire que l’URL inclut bien le paramètre de version et que `no-store` est utilisé

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba0fccc7f88320a175bf22f11f2fc6