### PR TITLE
Log des erreurs de configuration lors du fallback

### DIFF
--- a/bolt-app/src/utils/api/sheets/index.ts
+++ b/bolt-app/src/utils/api/sheets/index.ts
@@ -20,6 +20,13 @@ export async function fetchAllVideos(): Promise<ApiResponse<VideoData[]>> {
   // Si une erreur est détectée ou si un message d'aide est présent,
   // on se rabat sur les données locales au lieu d'interroger les API externes.
   if (config.error || config.help) {
+    if (config.error) {
+      console.error('Configuration error:', config.error);
+    }
+    if (config.help) {
+      console.warn('Configuration help:', config.help);
+    }
+
     return {
       ...localResponse,
       // On conserve l'erreur d'origine seulement si elle existe ; sinon, on garde l'erreur locale


### PR DESCRIPTION
## Résumé
- journalisation côté client des erreurs ou aides de configuration lorsque l'app bascule sur les données locales

## Tests
- `npm test`
- `npm run lint`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc675a561483208ea4956f0be2ba0d