### PR TITLE
Déclenchement du déploiement après les workflows de synchronisation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,8 @@
 name: Build and deploy to GitHub Pages
 
 on:
+  push:
+    branches: ["main"]
   workflow_run:
     workflows: ["YouTube to Sheets Sync", "Export Google Sheet to public data"]
     types: [completed]


### PR DESCRIPTION
## Résumé
- Réactivation du déclenchement du workflow de déploiement lors des `push` sur `main`

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc6ba190c4832083944711e662d7d6