### PR TITLE
fix: update Safari mask icon

### DIFF
--- a/bolt-app/index.html
+++ b/bolt-app/index.html
@@ -5,7 +5,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
-    <link rel="mask-icon" href="icon.svg" color="#ff0000" />
+    <link rel="mask-icon" href="mask-icon.svg" color="#ff0000" />
     <link rel="icon" href="icon.svg" type="image/svg+xml" />
     <link rel="shortcut icon" href="favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />

--- a/bolt-app/public/mask-icon.svg
+++ b/bolt-app/public/mask-icon.svg
@@ -1,3 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <path fill="#000000" fill-rule="evenodd" d="M 0 0 h 512 v 512 h -512 z M 224 170 L 224 342 L 366 256 Z"/>
+  <path
+    fill="#000"
+    fill-rule="evenodd"
+    d="M96 0h320a96 96 0 0 1 96 96v320a96 96 0 0 1-96 96h-320a96 96 0 0 1-96-96v-320a96 96 0 0 1 96-96z M224 170L224 342L366 256Z"/>
 </svg>


### PR DESCRIPTION
## Summary
- reference monochrome mask icon for Safari pinned tabs
- adjust mask-icon.svg to mirror favicon shape

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc73ea1e5c8320854057a1e55f48c8