### PR TITLE
Fait défiler en haut lors du reset et du tap iOS

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -34,6 +34,8 @@ export default function App() {
 
   const resetFilters = React.useCallback(async () => {
     playClick();
+    // Remonte en haut de la page pour retrouver l'entête
+    window.scrollTo({ top: 0, behavior: 'smooth' });
     setSelectedTab(-1);
     setSearchFilters({
       query: '',
@@ -46,6 +48,15 @@ export default function App() {
   React.useEffect(() => {
     loadVideos();
   }, [loadVideos]);
+
+  // Permet de remonter en haut quand on tape la barre d'état iOS
+  React.useEffect(() => {
+    const handleStatusTap = () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    window.addEventListener('statusTap', handleStatusTap);
+    return () => window.removeEventListener('statusTap', handleStatusTap);
+  }, []);
 
   const filteredBySearch = React.useMemo(
     () => filterVideosBySearch(videos, searchFilters),

--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -36,6 +36,8 @@ export default function App() {
 
   const resetFilters = React.useCallback(async () => {
     playClick();
+    // Assure un retour en haut de l'écran sur iOS
+    window.scrollTo({ top: 0, behavior: 'smooth' });
     setSelectedTab(-1);
     setSearchFilters({
       query: '',
@@ -49,6 +51,15 @@ export default function App() {
   React.useEffect(() => {
     loadVideos();
   }, [loadVideos]);
+
+  // Permet de remonter en haut quand on tape la barre d'état iOS
+  React.useEffect(() => {
+    const handleStatusTap = () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+    window.addEventListener('statusTap', handleStatusTap);
+    return () => window.removeEventListener('statusTap', handleStatusTap);
+  }, []);
 
   const filteredBySearch = React.useMemo(
     () => filterVideosBySearch(videos, searchFilters),


### PR DESCRIPTION
## Résumé
- fait remonter la page en haut lors du clic sur le bouton de réinitialisation
- synchronise le comportement dans l’application React et la version bolt-app
- ajoute un listener `statusTap` pour remonter en haut quand on tape sur la barre d’état iOS

## Tests
- `npm run lint`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bebd1661848320bb4a67a6842d1f7d