### PR TITLE
Fait défiler en haut lors du reset et du tap iOS

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,20 +32,37 @@ export default function App() {
     fields: ['title', 'channel', 'category']
   });
 
+  const scrollToTop = React.useCallback(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    document.body?.scrollTo?.({ top: 0, behavior: 'smooth' });
+    document.documentElement?.scrollTo?.({ top: 0, behavior: 'smooth' });
+  }, []);
+
   const resetFilters = React.useCallback(async () => {
     playClick();
+    // Remonte en haut de la page pour retrouver l'entête
+    scrollToTop();
     setSelectedTab(-1);
     setSearchFilters({
       query: '',
       fields: ['title', 'channel', 'category']
     });
     await loadVideos();
-  }, [loadVideos, playClick]);
+  }, [loadVideos, playClick, scrollToTop]);
 
   // Charge toujours les vidéos, même sans configuration Sheets
   React.useEffect(() => {
     loadVideos();
   }, [loadVideos]);
+
+  // Permet de remonter en haut quand on tape la barre d'état iOS
+  React.useEffect(() => {
+    const handleStatusTap = () => {
+      scrollToTop();
+    };
+    window.addEventListener('statusTap', handleStatusTap);
+    return () => window.removeEventListener('statusTap', handleStatusTap);
+  }, [scrollToTop]);
 
   const filteredBySearch = React.useMemo(
     () => filterVideosBySearch(videos, searchFilters),

--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -34,8 +34,16 @@ export default function App() {
   });
   const [selectedCategory, setSelectedCategory] = React.useState<string | null>(null);
 
+  const scrollToTop = React.useCallback(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+    document.body?.scrollTo?.({ top: 0, behavior: 'smooth' });
+    document.documentElement?.scrollTo?.({ top: 0, behavior: 'smooth' });
+  }, []);
+
   const resetFilters = React.useCallback(async () => {
     playClick();
+    // Assure un retour en haut de l'écran sur iOS
+    scrollToTop();
     setSelectedTab(-1);
     setSearchFilters({
       query: '',
@@ -43,12 +51,21 @@ export default function App() {
     });
     setSelectedCategory(null);
     await loadVideos();
-  }, [loadVideos, playClick]);
+  }, [loadVideos, playClick, scrollToTop]);
 
   // Charge toujours les vidéos, même sans configuration Sheets
   React.useEffect(() => {
     loadVideos();
   }, [loadVideos]);
+
+  // Permet de remonter en haut quand on tape la barre d'état iOS
+  React.useEffect(() => {
+    const handleStatusTap = () => {
+      scrollToTop();
+    };
+    window.addEventListener('statusTap', handleStatusTap);
+    return () => window.removeEventListener('statusTap', handleStatusTap);
+  }, [scrollToTop]);
 
   const filteredBySearch = React.useMemo(
     () => filterVideosBySearch(videos, searchFilters),


### PR DESCRIPTION
## Résumé
- centralise `scrollToTop` pour faire défiler `window`, `body` et `documentElement`
- réutilise cette logique lors du reset et du tap sur la barre d’état iOS
- synchronise le même comportement dans la version bolt-app

## Tests
- `npm run lint` *(échec: package.json introuvable à la racine)*
- `cd bolt-app && npm run lint`
- `npm test` *(échec: package.json introuvable à la racine)*
- `cd bolt-app && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bebd1661848320bb4a67a6842d1f7d