### PR TITLE
Ouvre directement les vidéos dans l'app YouTube

### DIFF
--- a/bolt-app/src/utils/videoUtils.ts
+++ b/bolt-app/src/utils/videoUtils.ts
@@ -45,5 +45,32 @@ export function getRandomVideo(videos: VideoData[], tab: SheetTab | null): Video
 
 export function playVideo(video: VideoData | null) {
   if (!video) return;
+
+  // Essaye d'ouvrir directement l'application YouTube via son schéma d'URL.
+  const videoId = extractYouTubeId(video.link);
+
+  if (videoId) {
+    const appUrl = `youtube://${videoId}`;
+    const webUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+    // Ouvre l'application YouTube. Si elle n'est pas installée,
+    // redirige vers l'URL web après un court délai.
+    const timeoutId = setTimeout(() => {
+      window.open(webUrl, '_blank', 'noopener,noreferrer');
+    }, 500);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        clearTimeout(timeoutId);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.location.href = appUrl;
+    return;
+  }
+
+  // Si l'ID de la vidéo n'est pas détecté, on ouvre simplement le lien.
   window.open(video.link, '_blank', 'noopener,noreferrer');
 }


### PR DESCRIPTION
## Résumé
- supprime la fenêtre intermédiaire en ouvrant YouTube via `window.location` et annule la redirection web si l'application prend le focus

## Tests
- `npm --prefix bolt-app run lint`
- `npm --prefix bolt-app test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c49256c3048320b38296b193882839