### PR TITLE
Fix dropdown anchor offsets during scroll

### DIFF
--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown } from 'lucide-react';
 import { useClickOutside } from '../../hooks/useClickOutside';
 
@@ -11,20 +12,132 @@ interface DropdownMenuProps {
   className?: string;
 }
 
-export function DropdownMenu({ 
-  icon, 
-  label, 
-  isOpen, 
-  onToggle, 
+export function DropdownMenu({
+  icon,
+  label,
+  isOpen,
+  onToggle,
   children,
   className = ''
 }: DropdownMenuProps) {
-  const menuRef = useClickOutside<HTMLDivElement>(() => isOpen && onToggle());
+  const menuContentRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = useClickOutside<HTMLDivElement>(
+    () => isOpen && onToggle(),
+    [menuContentRef, triggerRef],
+  );
+  const [menuPosition, setMenuPosition] = React.useState({
+    top: 0,
+    left: 0,
+    width: 0,
+  });
+
+  const animationFrameRef = React.useRef<number | null>(null);
+  const [portalContainer, setPortalContainer] = React.useState<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    setPortalContainer(document.body);
+  }, []);
+
+  const updateMenuPosition = React.useCallback(() => {
+    if (!isOpen || !triggerRef.current) return;
+    if (typeof window === 'undefined') return;
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const viewport = window.visualViewport;
+    const viewportWidth = viewport?.width ?? window.innerWidth;
+    const viewportOffsetLeft = viewport?.offsetLeft ?? 0;
+    const viewportOffsetTop = viewport?.offsetTop ?? 0;
+    const spacing = 8; // équivalent Tailwind de mt-2
+    const isSmallScreen = viewportWidth < 640; // breakpoint Tailwind "sm"
+    const horizontalMargin = 16; // correspond à mx-4
+    const availableWidth = Math.max(viewportWidth - horizontalMargin * 2, 0);
+
+    const desiredWidth = isSmallScreen
+      ? Math.max(availableWidth, triggerRect.width)
+      : Math.min(280, Math.max(availableWidth, triggerRect.width));
+
+    const width = desiredWidth > 0 ? desiredWidth : triggerRect.width;
+
+    let left = isSmallScreen
+      ? horizontalMargin
+      : triggerRect.left - viewportOffsetLeft;
+    const minLeft = horizontalMargin;
+    const maxLeft = viewportWidth - horizontalMargin - width;
+    if (maxLeft < minLeft) {
+      left = minLeft;
+    } else {
+      left = Math.min(Math.max(left, minLeft), maxLeft);
+    }
+
+    const top = triggerRect.bottom + spacing - viewportOffsetTop;
+
+    setMenuPosition((prev) => {
+      if (
+        Math.abs(prev.top - top) < 0.5 &&
+        Math.abs(prev.left - left) < 0.5 &&
+        Math.abs(prev.width - width) < 0.5
+      ) {
+        return prev;
+      }
+
+      return { top, left, width };
+    });
+  }, [isOpen]);
+
+  const scheduleMenuPositionUpdate = React.useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (animationFrameRef.current !== null) return;
+
+    animationFrameRef.current = window.requestAnimationFrame(() => {
+      animationFrameRef.current = null;
+      updateMenuPosition();
+    });
+  }, [animationFrameRef, updateMenuPosition]);
+
+  React.useLayoutEffect(() => {
+    updateMenuPosition();
+  }, [isOpen, updateMenuPosition]);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    scheduleMenuPositionUpdate();
+
+    const handleResize = () => scheduleMenuPositionUpdate();
+    const handleScroll = () => scheduleMenuPositionUpdate();
+    const viewport = typeof window !== 'undefined' ? window.visualViewport : null;
+
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, true);
+    viewport?.addEventListener('resize', handleResize);
+    viewport?.addEventListener('scroll', handleResize);
+
+    return () => {
+      if (animationFrameRef.current !== null && typeof window !== 'undefined') {
+        window.cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleScroll, true);
+      viewport?.removeEventListener('resize', handleResize);
+      viewport?.removeEventListener('scroll', handleResize);
+    };
+  }, [isOpen, scheduleMenuPositionUpdate, animationFrameRef]);
 
   return (
     <div className="relative" ref={menuRef}>
       <button
+        ref={triggerRef}
         onClick={onToggle}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
         className={`neu-button px-3 sm:px-4 py-2 rounded-xl flex items-center gap-2 w-full group ${className}`}
       >
         <span className="text-gray-500 group-hover:text-youtube-red transition-colors shrink-0">
@@ -40,15 +153,25 @@ export function DropdownMenu({
         />
       </button>
 
-      {isOpen && (
-        <div className="fixed sm:absolute z-50 mt-2 w-[calc(100vw-2rem)] sm:w-[280px] left-0 right-0 sm:left-0 sm:right-auto mx-4 sm:mx-0">
-          <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
-            <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
-              {children}
+      {portalContainer && isOpen &&
+        createPortal(
+          <div
+            ref={menuContentRef}
+            className="fixed z-50"
+            style={{
+              top: menuPosition.top,
+              left: menuPosition.left,
+              width: menuPosition.width || undefined,
+            }}
+          >
+            <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
+              <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
+                {children}
+              </div>
             </div>
-          </div>
-        </div>
-      )}
+          </div>,
+          portalContainer,
+        )}
     </div>
   );
 }

--- a/bolt-app/src/hooks/useClickOutside.ts
+++ b/bolt-app/src/hooks/useClickOutside.ts
@@ -1,18 +1,52 @@
 import React from 'react';
 
-export function useClickOutside<T extends HTMLElement>(callback: () => void) {
+type PossibleRef =
+  | React.RefObject<HTMLElement | null>
+  | React.MutableRefObject<HTMLElement | null>;
+
+export function useClickOutside<T extends HTMLElement>(
+  callback: () => void,
+  additionalRefs: PossibleRef[] = [],
+) {
   const ref = React.useRef<T>(null);
 
+  const latestCallback = React.useRef(callback);
+  latestCallback.current = callback;
+
+  const trackedAdditionalRefs = React.useRef(additionalRefs);
+  trackedAdditionalRefs.current = additionalRefs;
+
   React.useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        callback();
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+
+      if (!ref.current) {
+        return;
       }
+
+      if (ref.current.contains(target)) {
+        return;
+      }
+
+      const isInsideAdditional = trackedAdditionalRefs.current.some((extraRef) =>
+        extraRef.current ? extraRef.current.contains(target) : false,
+      );
+
+      if (isInsideAdditional) {
+        return;
+      }
+
+      latestCallback.current();
     };
 
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [callback]);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, []);
 
   return ref;
 }


### PR DESCRIPTION
## Summary
- corrige le calcul gauche/haut du menu portalisé pour compenser correctement les offsets du VisualViewport
- conserve les marges latérales sur mobile tout en empêchant le menu de dériver lors du scroll

## Testing
- npm run lint
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cf1b0acc28832087e8c692d2d48c1f