### PR TITLE
Simplify dropdown positioning to avoid scroll lag

### DIFF
--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -17,101 +17,17 @@ export function DropdownMenu({
   isOpen,
   onToggle,
   children,
-  className = ''
+  className = '',
 }: DropdownMenuProps) {
-  const menuRef = useClickOutside<HTMLDivElement>(() => isOpen && onToggle());
-  const triggerRef = React.useRef<HTMLButtonElement>(null);
-  const rafRef = React.useRef<number>();
-  const listenerOptions = React.useRef<{ capture: boolean; passive: boolean }>({
-    capture: true,
-    passive: true,
-  });
-  const [menuPosition, setMenuPosition] = React.useState({
-    top: 0,
-    left: 0,
-    width: 0,
-  });
-
-  const updateMenuPosition = React.useCallback(() => {
-    if (!isOpen || !triggerRef.current) return;
-    if (typeof window === 'undefined') return;
-
-    const triggerRect = triggerRef.current.getBoundingClientRect();
-    const spacing = 8; // équivalent Tailwind de mt-2
-    const viewportWidth = window.innerWidth;
-    const isSmallScreen = viewportWidth < 640; // breakpoint Tailwind "sm"
-    const horizontalMargin = 16; // correspond à mx-4
-    const availableWidth = Math.max(viewportWidth - horizontalMargin * 2, 0);
-
-    const desiredWidth = isSmallScreen
-      ? Math.max(availableWidth, triggerRect.width)
-      : Math.min(280, Math.max(availableWidth, triggerRect.width));
-
-    const width = desiredWidth > 0 ? desiredWidth : triggerRect.width;
-
-    let left = isSmallScreen ? horizontalMargin : triggerRect.left;
-    const maxLeft = viewportWidth - horizontalMargin - width;
-    if (maxLeft < horizontalMargin) {
-      left = horizontalMargin;
-    } else {
-      left = Math.min(Math.max(left, horizontalMargin), maxLeft);
+  const menuRef = useClickOutside<HTMLDivElement>(() => {
+    if (isOpen) {
+      onToggle();
     }
-
-    const top = triggerRect.bottom + spacing;
-
-    setMenuPosition((prev) => {
-      if (
-        Math.abs(prev.top - top) < 0.5 &&
-        Math.abs(prev.left - left) < 0.5 &&
-        Math.abs(prev.width - width) < 0.5
-      ) {
-        return prev;
-      }
-
-      return { top, left, width };
-    });
-  }, [isOpen]);
-
-  React.useLayoutEffect(() => {
-    updateMenuPosition();
-  }, [isOpen, updateMenuPosition]);
-
-  const scheduleUpdate = React.useCallback(() => {
-    if (!isOpen) return;
-    if (typeof window === 'undefined') return;
-
-    if (rafRef.current !== undefined) {
-      return;
-    }
-
-    rafRef.current = window.requestAnimationFrame(() => {
-      rafRef.current = undefined;
-      updateMenuPosition();
-    });
-  }, [isOpen, updateMenuPosition]);
-
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    scheduleUpdate();
-
-    window.addEventListener('resize', scheduleUpdate);
-    window.addEventListener('scroll', scheduleUpdate, listenerOptions.current);
-
-    return () => {
-      window.removeEventListener('resize', scheduleUpdate);
-      window.removeEventListener('scroll', scheduleUpdate, listenerOptions.current);
-      if (rafRef.current !== undefined && typeof window !== 'undefined') {
-        window.cancelAnimationFrame(rafRef.current);
-        rafRef.current = undefined;
-      }
-    };
-  }, [isOpen, scheduleUpdate]);
+  });
 
   return (
     <div className="relative" ref={menuRef}>
       <button
-        ref={triggerRef}
         onClick={onToggle}
         className={`neu-button px-3 sm:px-4 py-2 rounded-xl flex items-center gap-2 w-full group ${className}`}
       >
@@ -121,7 +37,7 @@ export function DropdownMenu({
         <span className="text-sm text-gray-700 dark:text-gray-200 truncate flex-1 text-left">
           {label}
         </span>
-        <ChevronDown 
+        <ChevronDown
           className={`w-4 h-4 text-gray-500 transition-transform duration-200 shrink-0 ${
             isOpen ? 'transform rotate-180' : ''
           }`}
@@ -129,14 +45,7 @@ export function DropdownMenu({
       </button>
 
       {isOpen && (
-        <div
-          className="fixed z-50"
-          style={{
-            top: menuPosition.top,
-            left: menuPosition.left,
-            width: menuPosition.width || undefined,
-          }}
-        >
+        <div className="absolute left-0 right-0 mt-2 z-50">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
               {children}


### PR DESCRIPTION
## Summary
- reposition the dropdown menu using simple absolute positioning anchored to its trigger
- remove scroll and resize listeners that were forcing layout recalculations and causing lag when the header is sticky

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3f4e55f748320aa9b19025e9c97d5