### PR TITLE
Add playlist order sorting option

### DIFF
--- a/bolt-app/src/components/SortSelect.tsx
+++ b/bolt-app/src/components/SortSelect.tsx
@@ -13,6 +13,8 @@ interface SortSelectProps {
 
 export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
+  const playlistValue = getOptionValue(null);
+  const selectedValue = getOptionValue(options);
 
   const handleSelect = (value: string) => {
     if (!value) {
@@ -30,15 +32,26 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
       label={getSelectedLabel(options)}
       isOpen={isOpen}
       onToggle={() => setIsOpen(!isOpen)}
-  >      <div className="px-4 py-2">
+    >
+      <div className="px-4 py-2">
         <div className="text-xs font-medium text-gray-500 uppercase">Date de publication</div>
       </div>
+
+      <DropdownItem
+        key="playlist-order"
+        onClick={() => handleSelect(playlistValue)}
+        isSelected={selectedValue === playlistValue}
+      >
+        {SORT_LABELS[playlistValue]}
+      </DropdownItem>
+
+      <div className="my-1 border-t border-gray-100 dark:border-neutral-700" />
 
       {[SORT_OPTIONS.PUBLISHED_DESC, SORT_OPTIONS.PUBLISHED_ASC].map((option) => (
         <DropdownItem
           key={getOptionValue(option)}
           onClick={() => handleSelect(getOptionValue(option))}
-          isSelected={getOptionValue(options) === getOptionValue(option)}
+          isSelected={selectedValue === getOptionValue(option)}
         >
           {SORT_LABELS[getOptionValue(option)]}
         </DropdownItem>

--- a/bolt-app/src/components/SortSelect/index.tsx
+++ b/bolt-app/src/components/SortSelect/index.tsx
@@ -14,6 +14,7 @@ interface SortSelectProps {
 export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const menuRef = useClickOutside<HTMLDivElement>(() => setIsOpen(false));
+  const playlistValue = getOptionValue(null);
 
   // Log pour vérifier les props reçues
   React.useEffect(() => {
@@ -37,6 +38,7 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
 
   const selectedValue = getOptionValue(options);
   console.log('SortSelect - Selected value:', selectedValue);
+  const playlistLabel = SORT_LABELS[playlistValue];
 
   return (
     <div className="relative" ref={menuRef}>
@@ -61,6 +63,19 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
         <div className="fixed sm:absolute z-50 mt-2 w-[calc(100vw-2rem)] sm:w-[280px] left-0 right-0 sm:left-0 sm:right-auto mx-4 sm:mx-0">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2">
+              <button
+                onClick={() => handleSelect(playlistValue)}
+                className={`w-full px-4 py-2.5 text-sm text-left transition-all duration-200 ${
+                  selectedValue === playlistValue
+                    ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 font-medium'
+                    : 'text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-neutral-700'
+                }`}
+              >
+                {playlistLabel}
+              </button>
+
+              <div className="my-1 border-t border-gray-100 dark:border-neutral-700" />
+
               {[SORT_OPTIONS.PUBLISHED_DESC, SORT_OPTIONS.PUBLISHED_ASC].map((option) => (
                 <SortOption
                   key={getOptionValue(option)}

--- a/bolt-app/src/utils/sort/labels.ts
+++ b/bolt-app/src/utils/sort/labels.ts
@@ -3,12 +3,8 @@
 // Note: we no longer import `SortOptions` here because the type isn't used directly.
 
 // Mapping of internal sort option keys to their French labels.
-// Note: the key '' corresponds to a null sort option. Previously this
-// displayed "Sans tri", but since the UI no longer exposes an unsorted
-// state, we now map it to "Plus récentes" so that the newest videos
-// appear by default.
 export const SORT_LABELS: Record<string, string> = {
-  '': 'Plus récentes',
+  '': 'Comme la playlist YouTube',
   'publishedAt_desc': 'Plus récentes',
   'publishedAt_asc': 'Plus anciennes',
 };


### PR DESCRIPTION
## Summary
- add a playlist-order choice in the sorting dropdown so the grid can match the YouTube playlist ordering
- update sort labels and selection handling to display the new option alongside the existing publish date sorts

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3f72557d48320a4fb0b7841796234