### PR TITLE
Met à jour le libellé du tri de playlist

### DIFF
--- a/bolt-app/src/utils/sort/labels.ts
+++ b/bolt-app/src/utils/sort/labels.ts
@@ -4,7 +4,7 @@
 
 // Mapping of internal sort option keys to their French labels.
 export const SORT_LABELS: Record<string, string> = {
-  '': 'Comme la playlist YouTube',
+  '': 'Playlist d’origine',
   'publishedAt_desc': 'Plus récentes',
   'publishedAt_asc': 'Plus anciennes',
 };


### PR DESCRIPTION
## Summary
- remplace le libellé « Comme la playlist YouTube » par « Playlist d’origine » dans le menu de tri

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3ff7c35988320be1d5b033a7ab145