### PR TITLE
Définir la vue par défaut sur la playlist d'origine

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -37,10 +37,7 @@ export default function App() {
   const { videos, isLoading, error: videosError, loadVideos } = useVideos(configError);
   const { playClick } = useSound();
   const [selectedTab, setSelectedTab] = React.useState(-1);
-  const [sortOptions, setSortOptions] = React.useState<SortOptions>({
-    field: 'publishedAt',
-    direction: 'desc',
-  });
+  const [sortOptions, setSortOptions] = React.useState<SortOptions | null>(null);
   const [searchFilters, setSearchFilters] = React.useState<SearchFilters>({
     query: '',
     fields: ['title', 'channel', 'category'],
@@ -60,6 +57,7 @@ export default function App() {
       query: '',
       fields: ['title', 'channel', 'category'],
     });
+    setSortOptions(null);
     await loadVideos();
   }, [loadVideos, playClick, scrollToTop]);
 

--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -31,10 +31,7 @@ export default function App() {
   const { videos, isLoading, error: videosError, loadVideos } = useVideos(configError);
   const { playClick } = useSound();
   const [selectedTab, setSelectedTab] = React.useState(-1);
-  const [sortOptions, setSortOptions] = React.useState<SortOptions>({
-    field: 'publishedAt',
-    direction: 'desc',
-  });
+  const [sortOptions, setSortOptions] = React.useState<SortOptions | null>(null);
   const [searchFilters, setSearchFilters] = React.useState<SearchFilters>({
     query: '',
     fields: ['title', 'channel', 'category'],
@@ -55,6 +52,7 @@ export default function App() {
       query: '',
       fields: ['title', 'channel', 'category'],
     });
+    setSortOptions(null);
     setSelectedCategory(null);
     await loadVideos();
   }, [loadVideos, playClick, scrollToTop]);


### PR DESCRIPTION
## Résumé
- initialise le tri des vidéos sur la playlist d’origine au lancement de l’application
- réinitialise également le tri sur la playlist d’origine lors du reset des filtres

## Tests
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d403552b748320bc7f1e863b2e1024