### PR TITLE
Aligner l’ordre Playlist d’origine sur la playlist YouTube

### DIFF
--- a/bolt-app/src/utils/api/sheets/index.test.ts
+++ b/bolt-app/src/utils/api/sheets/index.test.ts
@@ -116,7 +116,7 @@ test('fetchAllVideos returns synchronized data on success', async () => {
   const { fetchAllVideos } = await import(`./index.ts?success=${Date.now()}`);
   const result = await fetchAllVideos();
 
-  assert.deepEqual(calls, ['local', 'sync']);
+  assert.deepEqual(calls, ['local', 'sync', 'sync']);
   assert.equal(result.data?.[0].title, 'Remote');
 
   mock.restoreAll();
@@ -179,7 +179,7 @@ test('fetchAllVideos keeps local data when synchronization fails', async () => {
   const { fetchAllVideos } = await import(`./index.ts?failure=${Date.now()}`);
   const result = await fetchAllVideos();
 
-  assert.deepEqual(calls, ['local', 'sync']);
+  assert.deepEqual(calls, ['local', 'sync', 'sync']);
   assert.equal(result.data?.[0].title, 'Local');
   assert.ok(result.metadata?.errors?.length);
   assert.ok(consoleError.mock.calls.length >= 1);


### PR DESCRIPTION
## Résumé
- récupère l’onglet AllVideos afin de reconstruire l’ordre natif de la playlist lors de la synchronisation
- trie les vidéos synchronisées selon l’ordre de référence, avec repli sur l’ordre d’insertion lorsque nécessaire
- ajuste les tests pour refléter l’appel supplémentaire à l’API Google Sheets

## Tests
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d4054236c88320b17e7ac49af007f5