### PR TITLE
Fix playlist order sorting

### DIFF
--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -13,6 +13,13 @@ export interface VideoData {
   category?: string; // Colonne L (YouTube numeric category)
   thumbnail: string; // Colonne M
   myCategory?: string; // Colonne N (custom category)
+  /**
+   * Position de la vidéo dans la playlist YouTube d’origine.
+   *
+   * Elle est utilisée pour rétablir l’ordre exact de la playlist quand
+   * l’utilisateur sélectionne « Playlist d’origine » dans le tri.
+   */
+  playlistPosition?: number;
 }
 
 export interface VideoResponse {

--- a/bolt-app/src/utils/api/sheets/local.ts
+++ b/bolt-app/src/utils/api/sheets/local.ts
@@ -12,7 +12,7 @@ export async function fetchLocalVideos(): Promise<ApiResponse<VideoData[]>> {
     const [, ...rows] = json as any[][]; // skip header row
     const videos = rows
       .filter(validateRow)
-      .map(mapRowToVideo);
+      .map((row, index) => mapRowToVideo(row, index));
 
     return { data: videos };
   } catch (err) {

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -1,6 +1,6 @@
 import type { VideoData } from '../../../types/video.ts';
 
-export function mapRowToVideo(row: any[]): VideoData {
+export function mapRowToVideo(row: any[], index = 0): VideoData {
   const safeString = (value: any, defaultValue: string = ''): string => {
     if (value === undefined || value === null || value === '') {
       return defaultValue;
@@ -8,7 +8,7 @@ export function mapRowToVideo(row: any[]): VideoData {
     return String(value);
   };
 
-  return {
+  const video: VideoData = {
     channelAvatar: safeString(row[0]), // Column A for channel avatar
     title: safeString(row[1]), // Column B
     link: safeString(row[2]), // Column C
@@ -24,4 +24,10 @@ export function mapRowToVideo(row: any[]): VideoData {
     thumbnail: safeString(row[12]), // Column M
     myCategory: safeString(row[13], ''), // Column N (custom category)
   };
+
+  if (typeof index === 'number' && Number.isFinite(index)) {
+    video.playlistPosition = index;
+  }
+
+  return video;
 }

--- a/bolt-app/src/utils/sortUtils.ts
+++ b/bolt-app/src/utils/sortUtils.ts
@@ -2,8 +2,30 @@ import type { VideoData } from '../types/video.ts';
 import type { SortOptions } from '../types/sort.ts';
 import { parseDate } from './timeUtils.ts';
 
+function sortByPlaylistPosition(videos: VideoData[]): VideoData[] {
+  return videos
+    .map((video, index) => ({ video, index }))
+    .sort((a, b) => {
+      const orderA = typeof a.video.playlistPosition === 'number'
+        ? a.video.playlistPosition
+        : Number.POSITIVE_INFINITY;
+      const orderB = typeof b.video.playlistPosition === 'number'
+        ? b.video.playlistPosition
+        : Number.POSITIVE_INFINITY;
+
+      if (orderA === orderB) {
+        return a.index - b.index;
+      }
+
+      return orderA - orderB;
+    })
+    .map(item => item.video);
+}
+
 export function sortVideos(videos: VideoData[], options: SortOptions | null): VideoData[] {
-  if (!options) return videos;
+  if (!options) {
+    return sortByPlaylistPosition(videos);
+  }
 
   console.log('Sorting videos:', {
     totalVideos: videos.length,


### PR DESCRIPTION
## Résumé
- ajoute un champ `playlistPosition` aux vidéos pour mémoriser l’ordre d’origine de la playlist
- renseigne cette position pour les jeux de données locaux et ceux synchronisés depuis Google Sheets
- utilise explicitement cette position pour rétablir l’ordre « Playlist d’origine » dans l’interface

## Tests
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d40eabab908320b11b9bf7868f6ac2