### PR TITLE
Aligner l’ordre « Playlist d’origine » sur YouTube

### DIFF
--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -13,6 +13,13 @@ export interface VideoData {
   category?: string; // Colonne L (YouTube numeric category)
   thumbnail: string; // Colonne M
   myCategory?: string; // Colonne N (custom category)
+  /**
+   * Position de la vidéo dans la playlist YouTube d’origine.
+   *
+   * Elle est utilisée pour rétablir l’ordre exact de la playlist quand
+   * l’utilisateur sélectionne « Playlist d’origine » dans le tri.
+   */
+  playlistPosition?: number;
 }
 
 export interface VideoResponse {

--- a/bolt-app/src/utils/api/sheets/index.test.ts
+++ b/bolt-app/src/utils/api/sheets/index.test.ts
@@ -28,7 +28,8 @@ test('fetchAllVideos uses local data when config error', async () => {
       '',
       '',
       '',
-      ''
+      '',
+      '0'
     ]
   ];
 
@@ -64,7 +65,7 @@ test('fetchAllVideos returns synchronized data on success', async () => {
   const { SHEET_TABS } = await import('../../constants.ts');
   const originalTabs = SHEET_TABS.map(tab => ({ ...tab }));
   SHEET_TABS.length = 1;
-  SHEET_TABS[0].range = 'tab!A2:M';
+  SHEET_TABS[0].range = 'tab!A2:O';
 
   const calls: string[] = [];
   const localRows = [
@@ -82,7 +83,8 @@ test('fetchAllVideos returns synchronized data on success', async () => {
       '',
       '',
       '',
-      ''
+      '',
+      '0'
     ]
   ];
   const remoteRows = [
@@ -99,7 +101,8 @@ test('fetchAllVideos returns synchronized data on success', async () => {
       '',
       '',
       '',
-      ''
+      '',
+      '0'
     ]
   ];
 
@@ -142,27 +145,28 @@ test('fetchAllVideos keeps local data when synchronization fails', async () => {
   const { SHEET_TABS } = await import('../../constants.ts');
   const originalTabs = SHEET_TABS.map(tab => ({ ...tab }));
   SHEET_TABS.length = 1;
-  SHEET_TABS[0].range = 'tab!A2:M';
+  SHEET_TABS[0].range = 'tab!A2:O';
 
   const calls: string[] = [];
   const localRows = [
     [],
-    [
-      '',
-      'Local',
-      'https://www.youtube.com/watch?v=local',
-      'Channel',
-      '2020-01-01T00:00:00Z',
-      'PT10M',
-      '0',
-      '0',
-      '0',
-      '',
-      '',
-      '',
-      ''
-    ]
-  ];
+      [
+        '',
+        'Local',
+        'https://www.youtube.com/watch?v=local',
+        'Channel',
+        '2020-01-01T00:00:00Z',
+        'PT10M',
+        '0',
+        '0',
+        '0',
+        '',
+        '',
+        '',
+        '',
+        '0'
+      ]
+    ];
 
   const fetchMock = mock.method(globalThis, 'fetch', async (input: any) => {
     const url = typeof input === 'string' ? input : input.url;

--- a/bolt-app/src/utils/api/sheets/local.ts
+++ b/bolt-app/src/utils/api/sheets/local.ts
@@ -12,7 +12,7 @@ export async function fetchLocalVideos(): Promise<ApiResponse<VideoData[]>> {
     const [, ...rows] = json as any[][]; // skip header row
     const videos = rows
       .filter(validateRow)
-      .map(mapRowToVideo);
+      .map((row, index) => mapRowToVideo(row, index));
 
     return { data: videos };
   } catch (err) {

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -1,6 +1,15 @@
 import type { VideoData } from '../../../types/video.ts';
 
-export function mapRowToVideo(row: any[]): VideoData {
+function parsePlaylistPosition(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function mapRowToVideo(row: any[], index = 0): VideoData {
   const safeString = (value: any, defaultValue: string = ''): string => {
     if (value === undefined || value === null || value === '') {
       return defaultValue;
@@ -8,7 +17,7 @@ export function mapRowToVideo(row: any[]): VideoData {
     return String(value);
   };
 
-  return {
+  const video: VideoData = {
     channelAvatar: safeString(row[0]), // Column A for channel avatar
     title: safeString(row[1]), // Column B
     link: safeString(row[2]), // Column C
@@ -24,4 +33,14 @@ export function mapRowToVideo(row: any[]): VideoData {
     thumbnail: safeString(row[12]), // Column M
     myCategory: safeString(row[13], ''), // Column N (custom category)
   };
+
+  const playlistPosition = parsePlaylistPosition(row[14]);
+
+  if (typeof playlistPosition === 'number') {
+    video.playlistPosition = playlistPosition;
+  } else if (typeof index === 'number' && Number.isFinite(index)) {
+    video.playlistPosition = index;
+  }
+
+  return video;
 }

--- a/bolt-app/src/utils/sortUtils.ts
+++ b/bolt-app/src/utils/sortUtils.ts
@@ -2,8 +2,30 @@ import type { VideoData } from '../types/video.ts';
 import type { SortOptions } from '../types/sort.ts';
 import { parseDate } from './timeUtils.ts';
 
+function sortByPlaylistPosition(videos: VideoData[]): VideoData[] {
+  return videos
+    .map((video, index) => ({ video, index }))
+    .sort((a, b) => {
+      const orderA = typeof a.video.playlistPosition === 'number'
+        ? a.video.playlistPosition
+        : Number.POSITIVE_INFINITY;
+      const orderB = typeof b.video.playlistPosition === 'number'
+        ? b.video.playlistPosition
+        : Number.POSITIVE_INFINITY;
+
+      if (orderA === orderB) {
+        return a.index - b.index;
+      }
+
+      return orderA - orderB;
+    })
+    .map(item => item.video);
+}
+
 export function sortVideos(videos: VideoData[], options: SortOptions | null): VideoData[] {
-  if (!options) return videos;
+  if (!options) {
+    return sortByPlaylistPosition(videos);
+  }
 
   console.log('Sorting videos:', {
     totalVideos: videos.length,

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ HEADERS = [
     "tags",
     "category",
     "thumbnail",
+    "myCategory",
+    "playlistPosition",
 ]
 
 # Valeurs par défaut pour les miniatures et avatars en cas d’absence de données
@@ -382,6 +384,12 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
             avatar_url = get_channel_avatar(channel_id, YOUTUBE_API_KEY)
             published_at = format_published_at(snippet.get("publishedAt", ""))
             duration_category = get_duration_category(video_duration)
+            playlist_position = item.get("snippet", {}).get("position")
+            if isinstance(playlist_position, int):
+                resolved_position = playlist_position
+            else:
+                resolved_position = len(all_videos)
+
             entry = [
                 avatar_url,
                 title,
@@ -396,6 +404,8 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
                 ", ".join(snippet.get("tags", []) or []),
                 snippet.get("categoryId", "Inconnu"),
                 thumbnail_url,
+                "",
+                resolved_position,
             ]
             add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
     # Écriture des données dans chaque onglet de catégorie


### PR DESCRIPTION
## Résumé
- ajoute une colonne `playlistPosition` dans le script de synchronisation afin de stocker l’ordre original de la playlist et de l’exporter dans Google Sheets ainsi que dans le JSON local
- lit cette colonne dans la transformation et la synchronisation côté front pour rétablir l’ordre même quand la feuille maître n’est pas disponible
- adapte les tests pour couvrir la nouvelle structure de données

## Tests
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d40eabab908320b11b9bf7868f6ac2