### PR TITLE
Fix playlist ordering for string positions

### DIFF
--- a/bolt-app/src/utils/sortUtils.test.ts
+++ b/bolt-app/src/utils/sortUtils.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sortVideos } from './sortUtils.ts';
+
+test('sortVideos respecte la position de playlist même avec des valeurs sous forme de chaîne', () => {
+  const videos = [
+    { title: 'Ancienne vidéo', playlistPosition: '2' },
+    { title: 'Plus récente', playlistPosition: '0' },
+    { title: 'Intermédiaire', playlistPosition: '1' },
+    { title: 'Sans position définie' }
+  ];
+
+  const sorted = sortVideos(videos as any, null);
+
+  assert.deepEqual(
+    sorted.map(video => video.title),
+    ['Plus récente', 'Intermédiaire', 'Ancienne vidéo', 'Sans position définie']
+  );
+});

--- a/bolt-app/src/utils/sortUtils.ts
+++ b/bolt-app/src/utils/sortUtils.ts
@@ -2,16 +2,17 @@ import type { VideoData } from '../types/video.ts';
 import type { SortOptions } from '../types/sort.ts';
 import { parseDate } from './timeUtils.ts';
 
+function getPlaylistOrder(value: VideoData['playlistPosition']): number {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : Number.POSITIVE_INFINITY;
+}
+
 function sortByPlaylistPosition(videos: VideoData[]): VideoData[] {
   return videos
     .map((video, index) => ({ video, index }))
     .sort((a, b) => {
-      const orderA = typeof a.video.playlistPosition === 'number'
-        ? a.video.playlistPosition
-        : Number.POSITIVE_INFINITY;
-      const orderB = typeof b.video.playlistPosition === 'number'
-        ? b.video.playlistPosition
-        : Number.POSITIVE_INFINITY;
+      const orderA = getPlaylistOrder(a.video.playlistPosition);
+      const orderB = getPlaylistOrder(b.video.playlistPosition);
 
       if (orderA === orderB) {
         return a.index - b.index;


### PR DESCRIPTION
## Summary
- normalise les valeurs de position de playlist en nombres avant le tri afin de respecter l'ordre d'ajout
- ajouter un test unitaire garantissant que le tri « Playlist d’origine » fonctionne même quand la position est stockée en chaîne

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4463206ec8320957bfa5fbf41bd75