### PR TITLE
Capture la position réelle des vidéos de la playlist

### DIFF
--- a/bolt-app/src/utils/api/sheets/transform.test.ts
+++ b/bolt-app/src/utils/api/sheets/transform.test.ts
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mapRowToVideo } from './transform.ts';
+
+test('mapRowToVideo lit la colonne playlistPosition si disponible', () => {
+  const row = [
+    'https://example.com/avatar.jpg',
+    'Titre de test',
+    'https://www.youtube.com/watch?v=abc123',
+    'Chaîne',
+    '2024-01-01T00:00:00Z',
+    '00:10',
+    '100',
+    '10',
+    '5',
+    'Description',
+    'tag1, tag2',
+    '22',
+    'https://example.com/thumb.jpg',
+    'Cat perso',
+    '42'
+  ];
+
+  const video = mapRowToVideo(row, 7);
+
+  assert.equal(video.playlistPosition, 42);
+});
+
+test('mapRowToVideo retombe sur l\'index lorsque la colonne est absente', () => {
+  const row = [
+    'https://example.com/avatar.jpg',
+    'Ancienne donnée',
+    'https://www.youtube.com/watch?v=def456',
+    'Chaîne',
+    '2024-02-01T00:00:00Z',
+    '00:05',
+    '200',
+    '20',
+    '10',
+    'Description',
+    'tag3, tag4',
+    '22',
+    'https://example.com/thumb.jpg'
+  ];
+
+  const video = mapRowToVideo(row, 5);
+
+  assert.equal(video.playlistPosition, 5);
+});
+
+test('mapRowToVideo ignore une valeur non numérique de playlistPosition', () => {
+  const row = [
+    'https://example.com/avatar.jpg',
+    'Valeur invalide',
+    'https://www.youtube.com/watch?v=ghi789',
+    'Chaîne',
+    '2024-03-01T00:00:00Z',
+    '00:07',
+    '300',
+    '30',
+    '15',
+    'Description',
+    'tag5',
+    '22',
+    'https://example.com/thumb.jpg',
+    '',
+    'not-a-number'
+  ];
+
+  const video = mapRowToVideo(row, 9);
+
+  assert.equal(video.playlistPosition, 9);
+});

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -8,6 +8,13 @@ export function mapRowToVideo(row: any[], index = 0): VideoData {
     return String(value);
   };
 
+  const playlistPositionRaw = row.length > 14 ? row[14] : undefined;
+  const parsedPosition = typeof playlistPositionRaw === 'number'
+    ? playlistPositionRaw
+    : typeof playlistPositionRaw === 'string' && playlistPositionRaw.trim() !== ''
+      ? Number(playlistPositionRaw.trim())
+      : Number.NaN;
+
   const video: VideoData = {
     channelAvatar: safeString(row[0]), // Column A for channel avatar
     title: safeString(row[1]), // Column B
@@ -25,7 +32,9 @@ export function mapRowToVideo(row: any[], index = 0): VideoData {
     myCategory: safeString(row[13], ''), // Column N (custom category)
   };
 
-  if (typeof index === 'number' && Number.isFinite(index)) {
+  if (Number.isFinite(parsedPosition)) {
+    video.playlistPosition = parsedPosition;
+  } else if (typeof index === 'number' && Number.isFinite(index)) {
     video.playlistPosition = index;
   }
 

--- a/bolt-app/src/utils/sortUtils.test.ts
+++ b/bolt-app/src/utils/sortUtils.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sortVideos } from './sortUtils.ts';
+
+test('sortVideos respecte la position de playlist même avec des valeurs sous forme de chaîne', () => {
+  const videos = [
+    { title: 'Ancienne vidéo', playlistPosition: '2' },
+    { title: 'Plus récente', playlistPosition: '0' },
+    { title: 'Intermédiaire', playlistPosition: '1' },
+    { title: 'Sans position définie' }
+  ];
+
+  const sorted = sortVideos(videos as any, null);
+
+  assert.deepEqual(
+    sorted.map(video => video.title),
+    ['Plus récente', 'Intermédiaire', 'Ancienne vidéo', 'Sans position définie']
+  );
+});

--- a/bolt-app/src/utils/sortUtils.ts
+++ b/bolt-app/src/utils/sortUtils.ts
@@ -2,16 +2,17 @@ import type { VideoData } from '../types/video.ts';
 import type { SortOptions } from '../types/sort.ts';
 import { parseDate } from './timeUtils.ts';
 
+function getPlaylistOrder(value: VideoData['playlistPosition']): number {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : Number.POSITIVE_INFINITY;
+}
+
 function sortByPlaylistPosition(videos: VideoData[]): VideoData[] {
   return videos
     .map((video, index) => ({ video, index }))
     .sort((a, b) => {
-      const orderA = typeof a.video.playlistPosition === 'number'
-        ? a.video.playlistPosition
-        : Number.POSITIVE_INFINITY;
-      const orderB = typeof b.video.playlistPosition === 'number'
-        ? b.video.playlistPosition
-        : Number.POSITIVE_INFINITY;
+      const orderA = getPlaylistOrder(a.video.playlistPosition);
+      const orderB = getPlaylistOrder(b.video.playlistPosition);
 
       if (orderA === orderB) {
         return a.index - b.index;

--- a/export_data.py
+++ b/export_data.py
@@ -47,6 +47,8 @@ HEADERS = [
     "tags",
     "category",
     "thumbnail",
+    "myCategory",
+    "playlistPosition",
 ]
 
 def parse_spreadsheet_id(value: str) -> str | None:
@@ -100,7 +102,7 @@ def main() -> int:
         logging.error("SPREADSHEET_ID invalide: %s", raw_spreadsheet_id)
         return 1
     # Récupère toutes les données de l'onglet AllVideos (en-têtes + lignes)
-    range_all = "AllVideos!A1:M"
+    range_all = "AllVideos!A1:O"
     values = fetch_sheet_values(spreadsheet_id, api_key, range_all)
     if not values:
         logging.warning("Aucune donnée récupérée depuis la feuille.\n")

--- a/main.py
+++ b/main.py
@@ -38,6 +38,8 @@ HEADERS = [
     "tags",
     "category",
     "thumbnail",
+    "myCategory",
+    "playlistPosition",
 ]
 
 # Valeurs par défaut pour les miniatures et avatars en cas d’absence de données
@@ -382,6 +384,7 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
             avatar_url = get_channel_avatar(channel_id, YOUTUBE_API_KEY)
             published_at = format_published_at(snippet.get("publishedAt", ""))
             duration_category = get_duration_category(video_duration)
+            playlist_position = item.get("snippet", {}).get("position")
             entry = [
                 avatar_url,
                 title,
@@ -396,6 +399,8 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
                 ", ".join(snippet.get("tags", []) or []),
                 snippet.get("categoryId", "Inconnu"),
                 thumbnail_url,
+                "",  # myCategory (colonne personnalisée optionnelle)
+                str(playlist_position) if playlist_position is not None else "",
             ]
             add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
     # Écriture des données dans chaque onglet de catégorie

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -19,6 +19,8 @@ EXPECTED_HEADERS = [
     "tags",
     "category",
     "thumbnail",
+    "myCategory",
+    "playlistPosition",
 ]
 
 


### PR DESCRIPTION
## Summary
- ajoute les colonnes myCategory et playlistPosition à l'export et enregistre la position fournie par YouTube lors de la synchronisation
- expose cette position côté application en la lisant depuis la feuille et en couvrant le comportement par des tests unitaires
- adapte l'export JSON local pour inclure les nouvelles colonnes

## Testing
- npm run lint
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4463206ec8320957bfa5fbf41bd75