### PR TITLE
fix: open mobile dropdown menus upward

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -10,6 +10,7 @@ import { ErrorState } from './components/ErrorState';
 import { MissingConfig } from './components/MissingConfig';
 import { SoundToggle } from './components/ui/SoundToggle';
 import { ThemeToggle } from './components/ui/ThemeToggle';
+import { MobileFilterBar } from './components/MobileFilterBar';
 import { SHEET_TABS, getConfig } from './utils/constants';
 import { filterVideosByDuration } from './utils/videoFilters';
 import { filterVideosBySearch } from './utils/searchUtils';
@@ -146,7 +147,7 @@ export default function App() {
               </div>
             </div>
             {!isLoading && !appError && (
-              <div className="flex items-center justify-between gap-4">
+              <div className="hidden w-full sm:flex items-center justify-between gap-4">
                 <div className="w-full max-w-[280px]">
                   <SortSelect options={sortOptions} onOptionsChange={setSortOptions} />
                 </div>
@@ -162,7 +163,7 @@ export default function App() {
         </div>
       </header>
 
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-0">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-0 pb-32 sm:pb-0">
         {configError && <MissingConfig message={configError} />}
         {!isLoading && !appError && (
           <>
@@ -181,6 +182,16 @@ export default function App() {
         {appError && <ErrorState message={appError} />}
         {!isLoading && !appError && <VideoGrid videos={sortedVideos} />}
       </main>
+
+      {!isLoading && !appError && (
+        <MobileFilterBar
+          videos={videos}
+          sortOptions={sortOptions}
+          onSortOptionsChange={setSortOptions}
+          selectedCategory={selectedCategory}
+          onCategoryChange={setSelectedCategory}
+        />
+      )}
     </div>
   );
 }

--- a/bolt-app/src/components/CategorySelect.tsx
+++ b/bolt-app/src/components/CategorySelect.tsx
@@ -20,6 +20,8 @@ interface CategorySelectProps {
   onCategoryChange: (category: string | null) => void;
   /** Optional additional class names applied to the button */
   className?: string;
+  /** Controls whether the menu opens above or below the trigger */
+  menuPlacement?: 'top' | 'bottom';
 }
 
 export function CategorySelect({
@@ -27,6 +29,7 @@ export function CategorySelect({
   selectedCategory,
   onCategoryChange,
   className = '',
+  menuPlacement = 'bottom',
 }: CategorySelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -46,6 +49,7 @@ export function CategorySelect({
       isOpen={isOpen}
       onToggle={() => setIsOpen(!isOpen)}
       className={className}
+      placement={menuPlacement}
     >
       {/* Option to clear the category filter */}
       <DropdownItem

--- a/bolt-app/src/components/MobileFilterBar.tsx
+++ b/bolt-app/src/components/MobileFilterBar.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import type { SortOptions } from '../types/sort';
+import type { VideoData } from '../types/video';
+import { SortSelect } from './SortSelect';
+import { CategorySelect } from './CategorySelect';
+import { getUniqueCategories } from '../utils/getUniqueCategories';
+
+interface MobileFilterBarProps {
+  videos: VideoData[];
+  sortOptions: SortOptions | null;
+  onSortOptionsChange: (options: SortOptions | null) => void;
+  selectedCategory: string | null;
+  onCategoryChange: (category: string | null) => void;
+}
+
+export function MobileFilterBar({
+  videos,
+  sortOptions,
+  onSortOptionsChange,
+  selectedCategory,
+  onCategoryChange,
+}: MobileFilterBarProps) {
+  const hasCategories = React.useMemo(
+    () => getUniqueCategories(videos).length > 0,
+    [videos],
+  );
+
+  const containerStyle = React.useMemo(
+    () => ({ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)' }),
+    [],
+  );
+
+  return (
+    <div className="sm:hidden fixed inset-x-0 bottom-0 z-50">
+      <div
+        className="border-t border-gray-200/80 dark:border-neutral-700/80 bg-white/95 dark:bg-neutral-900/95 backdrop-blur shadow-[0_-12px_30px_rgba(15,15,15,0.18)] px-4 pt-3"
+        style={containerStyle}
+      >
+        <div className="flex items-center justify-between gap-2 mb-3">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-gray-500 dark:text-gray-400">
+            Filtres rapides
+          </span>
+          <div className="h-px flex-1 bg-gradient-to-r from-transparent via-gray-200/80 to-transparent dark:via-neutral-700/80" />
+        </div>
+        <div
+          className={`grid gap-3 ${hasCategories ? 'grid-cols-2' : 'grid-cols-1'}`}
+        >
+          <SortSelect
+            options={sortOptions}
+            onOptionsChange={onSortOptionsChange}
+            className="bg-white/70 dark:bg-neutral-800/70"
+            menuPlacement="top"
+          />
+          {hasCategories && (
+            <CategorySelect
+              videos={videos}
+              selectedCategory={selectedCategory}
+              onCategoryChange={onCategoryChange}
+              className="bg-white/70 dark:bg-neutral-800/70"
+              menuPlacement="top"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/bolt-app/src/components/SortSelect.tsx
+++ b/bolt-app/src/components/SortSelect.tsx
@@ -9,9 +9,16 @@ import { DropdownItem } from './ui/DropdownItem';
 interface SortSelectProps {
   options: SortOptions | null;
   onOptionsChange: (options: SortOptions | null) => void;
+  className?: string;
+  menuPlacement?: 'top' | 'bottom';
 }
 
-export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
+export function SortSelect({
+  options,
+  onOptionsChange,
+  className = '',
+  menuPlacement = 'bottom',
+}: SortSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const playlistValue = getOptionValue(null);
   const selectedValue = getOptionValue(options);
@@ -32,6 +39,8 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
       label={getSelectedLabel(options)}
       isOpen={isOpen}
       onToggle={() => setIsOpen(!isOpen)}
+      className={className}
+      placement={menuPlacement}
     >
       <div className="px-4 py-2">
         <div className="text-xs font-medium text-gray-500 uppercase">Date de publication</div>

--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -9,6 +9,7 @@ interface DropdownMenuProps {
   onToggle: () => void;
   children: React.ReactNode;
   className?: string;
+  placement?: 'top' | 'bottom';
 }
 
 export function DropdownMenu({
@@ -18,12 +19,18 @@ export function DropdownMenu({
   onToggle,
   children,
   className = '',
+  placement = 'bottom',
 }: DropdownMenuProps) {
   const menuRef = useClickOutside<HTMLDivElement>(() => {
     if (isOpen) {
       onToggle();
     }
   });
+
+  const menuPositionClass =
+    placement === 'top'
+      ? 'bottom-full mb-2'
+      : 'top-full mt-2';
 
   return (
     <div className="relative" ref={menuRef}>
@@ -45,7 +52,9 @@ export function DropdownMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 mt-2 z-50">
+        <div
+          className={`absolute left-0 right-0 z-50 ${menuPositionClass}`}
+        >
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
               {children}


### PR DESCRIPTION
## Summary
- allow DropdownMenu to accept a placement option so menus can open upward when needed
- extend SortSelect and CategorySelect to forward placement control and configure the mobile bar to open above the buttons

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d65cfee34c83208a5d27a82209ef52