### PR TITLE
Fait remonter les menus déroulants mobiles

### DIFF
--- a/bolt-app/src/components/SortSelect/index.tsx
+++ b/bolt-app/src/components/SortSelect/index.tsx
@@ -60,7 +60,7 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
       </button>
 
       {isOpen && (
-        <div className="fixed sm:absolute z-50 mt-2 w-[calc(100vw-2rem)] sm:w-[280px] left-0 right-0 sm:left-0 sm:right-auto mx-4 sm:mx-0">
+        <div className="absolute z-50 bottom-full mb-2 w-full sm:w-[280px] left-0 right-0 sm:right-auto">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2">
               <button

--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -45,7 +45,7 @@ export function DropdownMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 mt-2 z-50">
+        <div className="absolute left-0 right-0 bottom-full mb-2 z-50">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
               {children}


### PR DESCRIPTION
## Summary
- oriente les conteneurs des menus déroulants afin qu'ils s'affichent au-dessus de leur déclencheur
- adapte le menu de tri mobile pour conserver le même comportement ascendant

## Testing
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d665bda88483209590f47eaafd8a8a