### PR TITLE
Augmente la marge des menus déroulants

### DIFF
--- a/bolt-app/src/components/SortSelect/index.tsx
+++ b/bolt-app/src/components/SortSelect/index.tsx
@@ -60,7 +60,7 @@ export function SortSelect({ options, onOptionsChange }: SortSelectProps) {
       </button>
 
       {isOpen && (
-        <div className="fixed sm:absolute z-50 mt-2 w-[calc(100vw-2rem)] sm:w-[280px] left-0 right-0 sm:left-0 sm:right-auto mx-4 sm:mx-0">
+        <div className="absolute z-50 bottom-full mb-4 w-full sm:w-[280px] left-0 right-0 sm:right-auto">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2">
               <button

--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -45,7 +45,7 @@ export function DropdownMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 mt-2 z-50">
+        <div className="absolute left-0 right-0 bottom-full mb-4 z-50">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
               {children}


### PR DESCRIPTION
## Summary
- augmente l'espacement sous les menus déroulants génériques pour laisser davantage de marge avec le bas de l'écran
- applique le même espacement supplémentaire au sélecteur de tri afin d'assurer un alignement visuel cohérent

## Testing
- npm --prefix bolt-app run lint
- npm --prefix bolt-app test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d665bda88483209590f47eaafd8a8a