### PR TITLE
Augmente l'espace inférieur de la barre de filtres mobile

### DIFF
--- a/bolt-app/src/components/MobileFilterBar.tsx
+++ b/bolt-app/src/components/MobileFilterBar.tsx
@@ -26,7 +26,7 @@ export function MobileFilterBar({
   );
 
   const containerStyle = React.useMemo(
-    () => ({ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)' }),
+    () => ({ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.5rem)' }),
     [],
   );
 


### PR DESCRIPTION
## Résumé
- augmente l'espace réservé au bas d'écran pour la barre de filtres mobile afin d'éloigner les menus du bord

## Tests
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d682d128e88320a338e2459b20c056