### PR TITLE
Réduit les espacements de l'en-tête et des filtres

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -116,9 +116,9 @@ export default function App() {
   const appError = videosError;
 
   return (
-    <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-4">
-      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-12">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4">
+    <div className="min-h-screen bg-youtube-bg-light dark:bg-neutral-900 overflow-x-hidden pt-2">
+      <header className="bg-white dark:bg-neutral-800 shadow-sm sticky top-0 z-50 mb-6">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 py-3">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <button

--- a/bolt-app/src/components/DurationTabs.tsx
+++ b/bolt-app/src/components/DurationTabs.tsx
@@ -30,7 +30,7 @@ export function DurationTabs({ selectedTab, onTabChange, videos }: DurationTabsP
   }, [videos]);
 
   return (
-    <div className="mb-8">
+    <div className="mb-6">
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
         <div className="flex col-span-2 sm:col-span-1">
           <button

--- a/bolt-app/src/components/SearchBar.tsx
+++ b/bolt-app/src/components/SearchBar.tsx
@@ -84,7 +84,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
   }, []);
 
   return (
-    <div className="mb-8">
+    <div className="mb-6">
       <div className="relative max-w-[640px] mx-auto flex items-center gap-4">
         <div className="relative flex-1 group">
           {/* Calque visuel séparé pour éviter le décalage du curseur iOS quand backdrop-filter est appliqué au formulaire */}


### PR DESCRIPTION
## Summary
- diminue la marge supérieure de l'application et l'espacement sous l'en-tête pour réduire le vide sur mobile
- allège légèrement les marges autour de la barre de recherche et des onglets de durée

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d685afcce08320942941750c158b2f