### PR TITLE
Align shuffle button styling in light mode

### DIFF
--- a/bolt-app/src/components/ShuffleButton.tsx
+++ b/bolt-app/src/components/ShuffleButton.tsx
@@ -11,10 +11,10 @@ export function ShuffleButton({ onClick, disabled }: ShuffleButtonProps) {
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`p-2 rounded-r-lg transition-all duration-200 backdrop-blur-md bg-white/30 dark:bg-neutral-600/30 border border-white/40 dark:border-neutral-500/40 ${
+      className={`px-3 py-2 rounded-r-lg transition-all duration-200 flex items-center justify-center bg-neu-base dark:bg-neutral-700/50 ${
         disabled
-          ? 'text-gray-400 cursor-not-allowed shadow-neu-pressed'
-          : 'text-gray-700 dark:text-gray-200 hover:text-blue-600'
+          ? 'text-gray-400 cursor-not-allowed shadow-neu-pressed dark:shadow-neu-pressed-dark'
+          : 'text-gray-700 dark:text-gray-100 shadow-neu-flat dark:shadow-neu-flat-dark hover:shadow-neu-concave dark:hover:shadow-neu-concave-dark active:shadow-neu-pressed dark:active:shadow-neu-pressed-dark hover:text-youtube-red dark:hover:text-youtube-red'
       }`}
       title="Lecture aléatoire"
     >


### PR DESCRIPTION
## Summary
- harmonize the shuffle button background and hover styles with the duration tabs
- ensure the shuffle icon inherits the same light and dark theme colors as the tab buttons

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d689ef8364832097b01f855bd7705a