### PR TITLE
Fix dropdown direction on desktop

### DIFF
--- a/bolt-app/src/components/ui/DropdownMenu.tsx
+++ b/bolt-app/src/components/ui/DropdownMenu.tsx
@@ -45,7 +45,7 @@ export function DropdownMenu({
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 right-0 bottom-full mb-2 z-50">
+        <div className="absolute left-0 right-0 bottom-full mb-2 z-50 sm:top-full sm:bottom-auto sm:mb-0 sm:mt-2">
           <div className="overflow-hidden rounded-xl neu-card bg-white dark:bg-neutral-800">
             <div className="py-2 max-h-[60vh] overflow-y-auto custom-scrollbar">
               {children}


### PR DESCRIPTION
## Summary
- adjust the dropdown menu panel positioning so it opens downward on desktop while retaining upward expansion on mobile

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d94022f054832086f3c5cc2a356bce