### PR TITLE
Empêcher le zoom iOS sur la barre de recherche

### DIFF
--- a/bolt-app/src/components/SearchBar.tsx
+++ b/bolt-app/src/components/SearchBar.tsx
@@ -108,7 +108,7 @@ export function SearchBar({ filters, onFiltersChange }: SearchBarProps) {
                 placeholder="Rechercher"
                 value={filters.query}
                 onChange={(e) => onFiltersChange({ ...filters, query: e.target.value })}
-                className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-dark dark:placeholder-gray-400 text-sm focus:outline-none"
+                className="w-full pl-4 pr-10 h-10 rounded-l-full bg-transparent text-youtube-black dark:text-white placeholder-youtube-gray-dark dark:placeholder-gray-400 text-[16px] sm:text-sm focus:outline-none"
               />
               {filters.query && (
                 <button


### PR DESCRIPTION
## Summary
- Empêche Safari mobile de zoomer sur le champ de recherche en augmentant la taille de police par défaut
- Stabilise la barre de filtres mobile qui restait fixe après une saisie dans la recherche

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26189f3108320bbf2159fbc24c565