### PR TITLE
Changer l'ordre de priorité des schémas YouTube sur VisionOS

### DIFF
--- a/bolt-app/src/utils/videoUtils.test.ts
+++ b/bolt-app/src/utils/videoUtils.test.ts
@@ -174,7 +174,7 @@ test('playVideo tente d’ouvrir l’app sur visionOS avec fallback différé', 
 
   playVideo({ link: 'https://www.youtube.com/watch?v=vision123' } as any);
 
-  assert.equal(env.location.href, 'youtube://vision123');
+  assert.equal(env.location.href, 'youtube://www.youtube.com/watch?v=vision123');
   assert.equal(env.timeoutScheduled(), true);
 
   env.triggerAllTimeouts();
@@ -193,7 +193,7 @@ test('playVideo tente d’ouvrir l’app sur Safari macOS tactile (cas visionOS)
 
   playVideo({ link: 'https://www.youtube.com/watch?v=visionMac' } as any);
 
-  assert.equal(env.location.href, 'youtube://visionMac');
+  assert.equal(env.location.href, 'youtube://www.youtube.com/watch?v=visionMac');
   assert.equal(env.timeoutScheduled(), true);
 
   env.triggerAllTimeouts();
@@ -227,13 +227,28 @@ test('playVideo ignore un second clic rapproché vers la même vidéo', () => {
 
   env.setNow(1000);
   playVideo({ link: 'https://www.youtube.com/watch?v=vision123' } as any);
-  assert.equal(env.location.href, 'youtube://vision123');
+  assert.equal(env.location.href, 'youtube://www.youtube.com/watch?v=vision123');
 
   env.location.href = '';
   env.setNow(1500);
   playVideo({ link: 'https://www.youtube.com/watch?v=vision123' } as any);
 
   assert.equal(env.location.href, '');
+
+  env.restore();
+});
+
+test('playVideo respecte l’ordre des schémas visionOS avant le fallback web', () => {
+  const env = createMockEnvironment({
+    userAgent: 'Mozilla/5.0 (VisionOS) AppleWebKit/000.0 Safari/000.0',
+    maxTouchPoints: 5
+  });
+
+  playVideo({ link: 'https://www.youtube.com/watch?v=ordered001' } as any);
+  assert.equal(env.location.href, 'youtube://www.youtube.com/watch?v=ordered001');
+
+  env.triggerNextTimeout();
+  assert.equal(env.location.href, 'vnd.youtube://www.youtube.com/watch?v=ordered001');
 
   env.restore();
 });

--- a/bolt-app/src/utils/videoUtils.ts
+++ b/bolt-app/src/utils/videoUtils.ts
@@ -81,6 +81,9 @@ function isLikelyVisionOSDevice(): boolean {
 
 function buildYouTubeAppUrls(link: string, videoId: string): string[] {
   const appUrls = new Set<string>();
+  const webDerivedYoutubeUrl = `youtube://www.youtube.com/watch?v=${videoId}`;
+  const webDerivedVndYoutubeUrl = `vnd.youtube://www.youtube.com/watch?v=${videoId}`;
+  const idBasedYoutubeUrl = `youtube://${videoId}`;
 
   // Conversion recommandée pour YouTube: remplacer https:// par youtube://
   // (Universal Link en fallback web si le schéma n'est pas géré par l'OS/app).
@@ -98,17 +101,26 @@ function buildYouTubeAppUrls(link: string, videoId: string): string[] {
   }
 
   // Fallback très compatible pour les liens vidéo standards.
-  appUrls.add(`youtube://${videoId}`);
+  appUrls.add(idBasedYoutubeUrl);
 
   // Sur visionOS, on privilégie explicitement le schéma classique YouTube
   // avant tout fallback web, sans supposer de schéma propriétaire dédié.
-  if (isLikelyVisionOSDevice() && appUrls.has(`youtube://${videoId}`)) {
-    const prioritized = [`youtube://${videoId}`];
-    for (const url of appUrls) {
-      if (url !== `youtube://${videoId}`) {
+  if (isLikelyVisionOSDevice() && appUrls.has(idBasedYoutubeUrl)) {
+    const prioritized: string[] = [];
+    const pushIfAvailable = (url: string) => {
+      if (appUrls.has(url) && !prioritized.includes(url)) {
         prioritized.push(url);
       }
+    };
+
+    pushIfAvailable(webDerivedYoutubeUrl);
+    pushIfAvailable(webDerivedVndYoutubeUrl);
+    pushIfAvailable(idBasedYoutubeUrl);
+
+    for (const url of appUrls) {
+      pushIfAvailable(url);
     }
+
     return prioritized;
   }
 


### PR DESCRIPTION
### Motivation
- Corriger le comportement sur VisionOS pour ne plus prioriser `youtube://{videoId}` mais tenter d’abord la variante dérivée du lien web, afin d'améliorer la compatibilité avec les Universal Links et réduire les cas où le schéma simple échoue.

### Description
- Modifie `buildYouTubeAppUrls(link, videoId)` pour construire un `Set` de bases puis, sur VisionOS, produire explicitement un tableau priorisé sans doublons où l'ordre est : `youtube://www.youtube.com/watch?v=...`, `vnd.youtube://www.youtube.com/watch?v=...`, puis `youtube://{videoId}`, suivi des autres variantes détectées (fichiers modifiés : `bolt-app/src/utils/videoUtils.ts`).
- Conserve l'utilisation de `Set` pour éviter les doublons et génère un tableau final stable via un push explicite.
- Ne change pas l'API publique ni la logique d'exécution de `playVideo` : la fonction continue d'utiliser `appUrls[0]` puis `appUrls[1]` et enfin le repli web différé (aucune régression d'API macOS/iOS attendue).
- Met à jour les tests VisionOS pour refléter le nouvel ordre et ajoute un test vérifiant explicitement que VisionOS tente d'abord la variante `youtube://www.youtube.com/watch?v=...` puis `vnd.youtube://...` (fichier modifié : `bolt-app/src/utils/videoUtils.test.ts`).

### Testing
- Exécution de `npm run lint` dans `bolt-app` : réussite.
- Exécution de `npm test` dans `bolt-app` : toutes les suites et sous-tests sont passés (32 tests, 0 échec).
- Vérification manuelle que `playVideo` conserve le même comportement d'appel (`appUrls[0]`, retry sur `appUrls[1]`, puis fallback web) et que les tests VisionOS ont été ajustés pour le nouvel ordre.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ec67981083209f42c87e27e606ca)