### PR TITLE
Ajouter filtre par playlist et persistance de `playlistId`

### DIFF
--- a/bolt-app/src/App.tsx
+++ b/bolt-app/src/App.tsx
@@ -5,6 +5,7 @@ import { DurationTabs } from './components/DurationTabs';
 import { SearchBar } from './components/SearchBar';
 import { SortSelect } from './components/SortSelect';
 import { CategorySelect } from './components/CategorySelect';
+import { PlaylistSelect } from './components/PlaylistSelect';
 import { LoadingState } from './components/LoadingState';
 import { ErrorState } from './components/ErrorState';
 import { MissingConfig } from './components/MissingConfig';
@@ -38,6 +39,7 @@ export default function App() {
     fields: ['title', 'channel', 'category'],
   });
   const [selectedCategory, setSelectedCategory] = React.useState<string | null>(null);
+  const [selectedPlaylistId, setSelectedPlaylistId] = React.useState<string | null>(null);
 
   const scrollToTop = React.useCallback(
     () => window.scrollTo({ top: 0, behavior: 'smooth' }),
@@ -55,6 +57,7 @@ export default function App() {
     });
     setSortOptions(null);
     setSelectedCategory(null);
+    setSelectedPlaylistId(null);
     await loadVideos();
   }, [loadVideos, playClick, scrollToTop]);
 
@@ -100,12 +103,20 @@ export default function App() {
     [filteredBySearch, selectedCategory],
   );
 
+  const filteredByPlaylist = React.useMemo(
+    () =>
+      selectedPlaylistId
+        ? filteredByCategory.filter(v => v.playlistId === selectedPlaylistId)
+        : filteredByCategory,
+    [filteredByCategory, selectedPlaylistId],
+  );
+
   const filteredByDuration = React.useMemo(
     () =>
       selectedTab === -1
-        ? filteredByCategory
-        : filterVideosByDuration(filteredByCategory, SHEET_TABS[selectedTab]),
-    [filteredByCategory, selectedTab],
+        ? filteredByPlaylist
+        : filterVideosByDuration(filteredByPlaylist, SHEET_TABS[selectedTab]),
+    [filteredByPlaylist, selectedTab],
   );
 
   const sortedVideos = React.useMemo(
@@ -157,6 +168,12 @@ export default function App() {
                   onCategoryChange={setSelectedCategory}
                   className="w-full max-w-[280px]"
                 />
+                <PlaylistSelect
+                  videos={videos}
+                  selectedPlaylistId={selectedPlaylistId}
+                  onPlaylistChange={setSelectedPlaylistId}
+                  className="w-full max-w-[280px]"
+                />
               </div>
             )}
           </div>
@@ -174,7 +191,7 @@ export default function App() {
             <DurationTabs
               selectedTab={selectedTab}
               onTabChange={setSelectedTab}
-              videos={filteredByCategory}
+              videos={filteredByPlaylist}
             />
           </>
         )}

--- a/bolt-app/src/components/PlaylistSelect.tsx
+++ b/bolt-app/src/components/PlaylistSelect.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ListVideo } from 'lucide-react';
+import type { VideoData } from '../types/video';
+import { DropdownMenu } from './ui/DropdownMenu';
+import { DropdownItem } from './ui/DropdownItem';
+
+const NEW_PLAYLIST_ID = 'PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx';
+
+interface PlaylistSelectProps {
+  videos: VideoData[];
+  selectedPlaylistId: string | null;
+  onPlaylistChange: (playlistId: string | null) => void;
+  className?: string;
+}
+
+export function PlaylistSelect({
+  videos,
+  selectedPlaylistId,
+  onPlaylistChange,
+  className = '',
+}: PlaylistSelectProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const playlistIds = React.useMemo(
+    () => Array.from(new Set(videos.map(v => v.playlistId).filter(Boolean) as string[])),
+    [videos],
+  );
+
+  const hasNewPlaylist = playlistIds.includes(NEW_PLAYLIST_ID);
+  const label = selectedPlaylistId
+    ? selectedPlaylistId === NEW_PLAYLIST_ID
+      ? 'Nouvelle playlist'
+      : 'Playlist principale'
+    : 'Playlists';
+
+  if (playlistIds.length <= 1 && !hasNewPlaylist) return null;
+
+  return (
+    <DropdownMenu
+      icon={<ListVideo className="w-5 h-5" />}
+      label={label}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      className={className}
+    >
+      <DropdownItem
+        onClick={() => {
+          onPlaylistChange(null);
+          setIsOpen(false);
+        }}
+        isSelected={selectedPlaylistId === null}
+      >
+        Toutes les playlists
+      </DropdownItem>
+      {playlistIds.map((playlistId) => (
+        <DropdownItem
+          key={playlistId}
+          onClick={() => {
+            onPlaylistChange(playlistId);
+            setIsOpen(false);
+          }}
+          isSelected={selectedPlaylistId === playlistId}
+        >
+          {playlistId === NEW_PLAYLIST_ID ? 'Nouvelle playlist' : 'Playlist principale'}
+        </DropdownItem>
+      ))}
+    </DropdownMenu>
+  );
+}

--- a/bolt-app/src/types/video.ts
+++ b/bolt-app/src/types/video.ts
@@ -20,6 +20,7 @@ export interface VideoData {
    * l’utilisateur sélectionne « Playlist d’origine » dans le tri.
    */
   playlistPosition?: number;
+  playlistId?: string;
 }
 
 export interface VideoResponse {

--- a/bolt-app/src/utils/api/sheets/transform.ts
+++ b/bolt-app/src/utils/api/sheets/transform.ts
@@ -37,6 +37,10 @@ export function mapRowToVideo(row: any[], index = 0): VideoData {
   } else if (typeof index === 'number' && Number.isFinite(index)) {
     video.playlistPosition = index;
   }
+  const playlistIdRaw = row.length > 15 ? row[15] : undefined;
+  if (typeof playlistIdRaw === 'string' && playlistIdRaw.trim() !== '') {
+    video.playlistId = playlistIdRaw.trim();
+  }
 
   return video;
 }

--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ HEADERS = [
     "thumbnail",
     "myCategory",
     "playlistPosition",
+    "playlistId",
 ]
 
 # Valeurs par défaut pour les miniatures et avatars en cas d’absence de données
@@ -401,6 +402,7 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
                 thumbnail_url,
                 "",  # myCategory (colonne personnalisée optionnelle)
                 str(playlist_position) if playlist_position is not None else "",
+                playlist_source_id,
             ]
             add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
     # Écriture des données dans chaque onglet de catégorie

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -21,6 +21,7 @@ EXPECTED_HEADERS = [
     "thumbnail",
     "myCategory",
     "playlistPosition",
+    "playlistId",
 ]
 
 


### PR DESCRIPTION
### Motivation
- Permettre d’afficher et de filtrer séparément les vidéos provenant de playlists distinctes, y compris la playlist fournie `PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx`.
- Conserver l’origine (ID de playlist) dans les données exportées pour pouvoir regrouper/filtrer côté UI et lors de la synchronisation Sheets/JSON.
- Ajouter un contrôle UI non intrusif (menu déroulant) pour sélectionner la playlist active sans casser le comportement existant des filtres et onglets de durée.

### Description
- Ajout du champ `playlistId` au format de données vidéo front-end dans `bolt-app/src/types/video.ts` et lecture depuis la colonne correspondante dans `bolt-app/src/utils/api/sheets/transform.ts`.
- Ajout de la colonne `playlistId` aux `HEADERS` et inclusion dans chaque ligne exportée par le script de synchronisation `main.py` (écriture dans Sheets et `data/videos.json`).
- Nouveau composant `bolt-app/src/components/PlaylistSelect.tsx` qui expose un menu déroulant pour choisir une playlist (la playlist fournie est affichée comme `Nouvelle playlist`).
- Intégration du filtre playlist dans `bolt-app/src/App.tsx` avec état `selectedPlaylistId`, reset propre dans `resetFilters` et application du filtre avant les tabs de durée pour préserver la logique existante.
- Mise à jour du test d’en-têtes Python `tests/test_headers.py` pour inclure la nouvelle colonne `playlistId`.

### Testing
- Lint front-end : `cd bolt-app && npm run lint` — succès (aucune erreur relevée).
- Tests front-end : `cd bolt-app && npm test` — succès complet (32 tests passés).
- Tests Python racine : `pytest -q` — succès complet (23 tests passés).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1a6d9aac83209ff6f63ed76543d2)