### PR TITLE
feat(ui): libellé clair pour la playlist secondaire dans le sélecteur

### DIFF
--- a/bolt-app/src/components/PlaylistSelect.tsx
+++ b/bolt-app/src/components/PlaylistSelect.tsx
@@ -4,7 +4,13 @@ import type { VideoData } from '../types/video';
 import { DropdownMenu } from './ui/DropdownMenu';
 import { DropdownItem } from './ui/DropdownItem';
 
-const NEW_PLAYLIST_ID = 'PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx';
+const PLAYLIST_LABELS: Record<string, string> = {
+  PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx: 'Playlist secondaire',
+};
+
+function getPlaylistLabel(playlistId: string): string {
+  return PLAYLIST_LABELS[playlistId] ?? `Playlist ${playlistId.slice(0, 8)}…`;
+}
 
 interface PlaylistSelectProps {
   videos: VideoData[];
@@ -25,14 +31,9 @@ export function PlaylistSelect({
     [videos],
   );
 
-  const hasNewPlaylist = playlistIds.includes(NEW_PLAYLIST_ID);
-  const label = selectedPlaylistId
-    ? selectedPlaylistId === NEW_PLAYLIST_ID
-      ? 'Nouvelle playlist'
-      : 'Playlist principale'
-    : 'Playlists';
+  const label = selectedPlaylistId ? getPlaylistLabel(selectedPlaylistId) : 'Playlists';
 
-  if (playlistIds.length <= 1 && !hasNewPlaylist) return null;
+  if (playlistIds.length <= 1) return null;
 
   return (
     <DropdownMenu
@@ -60,7 +61,7 @@ export function PlaylistSelect({
           }}
           isSelected={selectedPlaylistId === playlistId}
         >
-          {playlistId === NEW_PLAYLIST_ID ? 'Nouvelle playlist' : 'Playlist principale'}
+          {getPlaylistLabel(playlistId)}
         </DropdownItem>
       ))}
     </DropdownMenu>


### PR DESCRIPTION
### Motivation
- Rendre la playlist supplémentaire identifiable dans l'UI et éviter les libellés ambigus (« principale / nouvelle ») pour faciliter le filtrage des vidéos.

### Description
- Modifie `bolt-app/src/components/PlaylistSelect.tsx` pour remplacer la logique ad hoc par une table `PLAYLIST_LABELS` et une fonction `getPlaylistLabel` qui fournit un libellé lisible (avec fallback) pour chaque `playlistId` et affiche ces libellés dans le menu.

### Testing
- Exécution de `npm run lint` dans `bolt-app` : succès.
- Exécution de `npm test` dans `bolt-app` : succès (tous les tests automatisés ont passé, 32 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1cf7670083209394e80d928f6e51)