### PR TITLE
Preserve playlistId during sheet sync, support multiple playlists, and update playlist label

### DIFF
--- a/bolt-app/src/components/PlaylistSelect.tsx
+++ b/bolt-app/src/components/PlaylistSelect.tsx
@@ -5,7 +5,7 @@ import { DropdownMenu } from './ui/DropdownMenu';
 import { DropdownItem } from './ui/DropdownItem';
 
 const PLAYLIST_LABELS: Record<string, string> = {
-  PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx: 'Playlist secondaire',
+  PLtBV_WamBQbCWySxrSDkbEcTYsxZ8FOvx: 'Playlist complémentaire',
 };
 
 function getPlaylistLabel(playlistId: string): string {

--- a/bolt-app/src/utils/api/sheets/sync.test.ts
+++ b/bolt-app/src/utils/api/sheets/sync.test.ts
@@ -124,3 +124,70 @@ test('buildMasterOrderMap privilégie la colonne playlistPosition lorsque dispon
   assert.equal(orderMap['https://youtu.be/c3'], 2);
   assert.equal(explicitCount, 2);
 });
+
+test('synchronizeSheets conserve playlistId pour alimenter le filtre playlist', async () => {
+  const masterValues = [
+    HEADER_ROW,
+    ['', 'Video A', 'https://www.youtube.com/watch?v=abc123', '', '', '', '', '', '', '', '', '', '', '', '0', 'PL_TEST_123'],
+  ];
+  const tabValues = [
+    HEADER_ROW,
+    [
+      'https://example.com/avatar.jpg',
+      'Video A',
+      'https://www.youtube.com/watch?v=abc123',
+      'Channel',
+      '2020-01-01T00:00:00Z',
+      'PT10M',
+      '100',
+      '10',
+      '1',
+      'Description',
+      'tag',
+      'Category',
+      'https://example.com/thumb.jpg',
+      '',
+      '0',
+      'PL_TEST_123',
+    ],
+  ];
+
+  const originalSpreadsheetId = process.env.SPREADSHEET_ID;
+  const originalApiKey = process.env.YOUTUBE_API_KEY;
+  process.env.SPREADSHEET_ID = 'test-id';
+  process.env.YOUTUBE_API_KEY = 'test-key';
+
+  const { synchronizeSheets } = await import(`./sync.ts?playlist=${Date.now()}`);
+  const { SHEET_TABS } = await import('../../constants.ts');
+  const originalTabs = SHEET_TABS.map(tab => ({ ...tab }));
+
+  try {
+    SHEET_TABS.length = 1;
+    SHEET_TABS[0].range = 'tab!A:Z';
+
+    mock.method(globalThis, 'fetch', async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('AllVideos')) {
+        return new Response(JSON.stringify({ values: masterValues }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ values: tabValues }), { status: 200 });
+    });
+
+    const videos = await synchronizeSheets();
+    assert.equal(videos.length, 1);
+    assert.equal(videos[0].playlistId, 'PL_TEST_123');
+  } finally {
+    mock.restoreAll();
+    SHEET_TABS.splice(0, SHEET_TABS.length, ...originalTabs);
+    if (originalSpreadsheetId === undefined) {
+      delete process.env.SPREADSHEET_ID;
+    } else {
+      process.env.SPREADSHEET_ID = originalSpreadsheetId;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.YOUTUBE_API_KEY;
+    } else {
+      process.env.YOUTUBE_API_KEY = originalApiKey;
+    }
+  }
+});

--- a/bolt-app/src/utils/api/sheets/sync.ts
+++ b/bolt-app/src/utils/api/sheets/sync.ts
@@ -166,7 +166,10 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
           description,
           tags,
           category,
-          thumbnail
+          thumbnail,
+          myCategory,
+          ,
+          playlistId
         ] = row.map(cell => String(cell || '').trim());
 
         // Skip rows with no link
@@ -199,6 +202,8 @@ export async function synchronizeSheets(): Promise<VideoData[]> {
             tags: tags || '',
             category: category || 'Non catégorisé',
             thumbnail: thumbnail || '',
+            myCategory: myCategory || '',
+            playlistId: playlistId || undefined,
             playlistPosition: typeof masterOrder === 'number' ? masterOrder : fallbackOrder
           };
 

--- a/main.py
+++ b/main.py
@@ -72,6 +72,19 @@ def parse_playlist_id(value: str) -> str | None:
     return None
 
 
+def parse_playlist_ids(value: str) -> list[str]:
+    """Extrait une liste d'identifiants de playlists (séparés par virgule ou saut de ligne)."""
+    candidates = re.split(r"[\n,]+", value or "")
+    parsed_ids: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        playlist_id = parse_playlist_id(candidate.strip())
+        if playlist_id and playlist_id not in seen:
+            seen.add(playlist_id)
+            parsed_ids.append(playlist_id)
+    return parsed_ids
+
+
 def parse_duration(iso_duration: str) -> str:
     """Convertit une durée ISO 8601 (ex. 'PT5M20S') en format 'HH:MM:SS'."""
     pattern = re.compile(r"^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$")
@@ -315,10 +328,10 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
     # Variables d’environnement requises
     YOUTUBE_API_KEY = os.environ.get("YOUTUBE_API_KEY")
     raw_spreadsheet_id = os.environ.get("SPREADSHEET_ID")
-    playlist_source_id = parse_playlist_id(playlist_id)
+    playlist_source_ids = parse_playlist_ids(playlist_id)
     SHEET_TAB_NAME = sheet_tab_name
-    if not playlist_source_id:
-        logging.error("PLAYLIST_ID invalide")
+    if not playlist_source_ids:
+        logging.error("PLAYLIST_ID invalide (aucune playlist valide détectée)")
         return
     if not raw_spreadsheet_id:
         logging.error("Variable d'environnement SPREADSHEET_ID manquante")
@@ -342,19 +355,23 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
         return
     creds = service_account.Credentials.from_service_account_info(creds_info, scopes=SCOPES)
     service = build("sheets", "v4", credentials=creds)
-    # Récupération des vidéos de la playlist
-    try:
-        items = fetch_all_playlist_items(playlist_source_id, YOUTUBE_API_KEY)
-    except RuntimeError:
-        logging.error("Impossible de récupérer les vidéos de la playlist")
-        return
-    if not items:
-        logging.warning(
-            "Aucun élément récupéré pour la playlist %s. Vérifiez l'identifiant ou la visibilité.",
-            playlist_source_id,
-        )
-    video_ids = [it["contentDetails"]["videoId"] for it in items]
-    videos_data = fetch_videos_details(video_ids, YOUTUBE_API_KEY)
+    all_items_by_playlist: list[tuple[str, list[dict]]] = []
+    all_video_ids: list[str] = []
+    for playlist_source_id in playlist_source_ids:
+        try:
+            items = fetch_all_playlist_items(playlist_source_id, YOUTUBE_API_KEY)
+        except RuntimeError:
+            logging.error("Impossible de récupérer les vidéos de la playlist %s", playlist_source_id)
+            return
+        if not items:
+            logging.warning(
+                "Aucun élément récupéré pour la playlist %s. Vérifiez l'identifiant ou la visibilité.",
+                playlist_source_id,
+            )
+        all_items_by_playlist.append((playlist_source_id, items))
+        all_video_ids.extend(it["contentDetails"]["videoId"] for it in items)
+
+    videos_data = fetch_videos_details(list(dict.fromkeys(all_video_ids)), YOUTUBE_API_KEY)
     # Catégories de durée pré‑définies
     videos_by_category: dict[str, list] = {
         "0-5min": [],
@@ -369,42 +386,43 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
     }
     # Liste globale de toutes les vidéos
     all_videos: list[list] = []
-    for item in items:
-        video_id = item["contentDetails"]["videoId"]
-        video_link = f"https://www.youtube.com/watch?v={video_id}"
-        info = videos_data.get(video_id, {})
-        if info:
-            snippet = info.get("snippet", {})
-            stats = info.get("statistics", {})
-            title = snippet.get("title", "Inconnu")
-            channel = snippet.get("channelTitle", "Inconnu")
-            channel_id = snippet.get("channelId", "")
-            duration_iso = info.get("contentDetails", {}).get("duration", "PT0S")
-            video_duration = parse_duration(duration_iso)
-            thumbnail_url = get_thumbnail_url(info)
-            avatar_url = get_channel_avatar(channel_id, YOUTUBE_API_KEY)
-            published_at = format_published_at(snippet.get("publishedAt", ""))
-            duration_category = get_duration_category(video_duration)
-            playlist_position = item.get("snippet", {}).get("position")
-            entry = [
-                avatar_url,
-                title,
-                video_link,
-                channel,
-                published_at,
-                video_duration,
-                stats.get("viewCount", "0"),
-                stats.get("likeCount", "0"),
-                stats.get("commentCount", "0"),
-                snippet.get("description", "")[:50],
-                ", ".join(snippet.get("tags", []) or []),
-                snippet.get("categoryId", "Inconnu"),
-                thumbnail_url,
-                "",  # myCategory (colonne personnalisée optionnelle)
-                str(playlist_position) if playlist_position is not None else "",
-                playlist_source_id,
-            ]
-            add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
+    for playlist_source_id, items in all_items_by_playlist:
+        for item in items:
+            video_id = item["contentDetails"]["videoId"]
+            video_link = f"https://www.youtube.com/watch?v={video_id}"
+            info = videos_data.get(video_id, {})
+            if info:
+                snippet = info.get("snippet", {})
+                stats = info.get("statistics", {})
+                title = snippet.get("title", "Inconnu")
+                channel = snippet.get("channelTitle", "Inconnu")
+                channel_id = snippet.get("channelId", "")
+                duration_iso = info.get("contentDetails", {}).get("duration", "PT0S")
+                video_duration = parse_duration(duration_iso)
+                thumbnail_url = get_thumbnail_url(info)
+                avatar_url = get_channel_avatar(channel_id, YOUTUBE_API_KEY)
+                published_at = format_published_at(snippet.get("publishedAt", ""))
+                duration_category = get_duration_category(video_duration)
+                playlist_position = item.get("snippet", {}).get("position")
+                entry = [
+                    avatar_url,
+                    title,
+                    video_link,
+                    channel,
+                    published_at,
+                    video_duration,
+                    stats.get("viewCount", "0"),
+                    stats.get("likeCount", "0"),
+                    stats.get("commentCount", "0"),
+                    snippet.get("description", "")[:50],
+                    ", ".join(snippet.get("tags", []) or []),
+                    snippet.get("categoryId", "Inconnu"),
+                    thumbnail_url,
+                    "",  # myCategory (colonne personnalisée optionnelle)
+                    str(playlist_position) if playlist_position is not None else "",
+                    playlist_source_id,
+                ]
+                add_video_to_categories(entry, duration_category, videos_by_category, all_videos)
     # Écriture des données dans chaque onglet de catégorie
     for category_name, rows in videos_by_category.items():
         write_category(service, SPREADSHEET_ID, category_name, rows)
@@ -427,8 +445,11 @@ def sync_videos(playlist_id: str, sheet_tab_name: str = "AllVideos") -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Synchronise une playlist YouTube vers Google Sheets")
-    parser.add_argument("playlist_id", help="Identifiant ou URL de la playlist YouTube")
+    parser = argparse.ArgumentParser(description="Synchronise une ou plusieurs playlists YouTube vers Google Sheets")
+    parser.add_argument(
+        "playlist_id",
+        help="Identifiant(s) ou URL(s) de playlist YouTube (séparés par des virgules si plusieurs)",
+    )
     parser.add_argument("--sheet-tab-name", default="AllVideos", help="Nom de l'onglet cible dans Google Sheets")
     args = parser.parse_args()
     sync_videos(args.playlist_id, args.sheet_tab_name)


### PR DESCRIPTION
### Motivation
- Ensure playlist identifiers are retained when synchronizing sheet tabs so the UI can filter by playlist.
- Allow the CLI to accept and process one or more playlist IDs/URLs in a single run.
- Adjust a French UI label to better match terminology.

### Description
- Update `synchronizeSheets` to capture and store `playlistId` (and `myCategory`) from sheet rows into `VideoData` so the playlist filter can be populated. 
- Add a new unit test `synchronizeSheets conserve playlistId pour alimenter le filtre playlist` in `src/utils/api/sheets/sync.test.ts` to verify `playlistId` is preserved. 
- Extend `main.py` with `parse_playlist_ids` and modify `sync_videos` to accept multiple playlist IDs/URLs, aggregate items from all playlists, deduplicate video IDs, and record the source `playlist_source_id` per row. 
- Change label string in `PlaylistSelect.tsx` from `Playlist secondaire` to `Playlist complémentaire`.

### Testing
- Added and ran the unit test in `src/utils/api/sheets/sync.test.ts` which asserts `playlistId` is preserved, and it passed.
- Existing sheet synchronization tests covering `parsePlaylistPosition` and `buildMasterOrderMap` were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1dd17960832082d3d3ec879e6bd2)