### PR TITLE
Harden Pages deployment retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,10 +77,22 @@ jobs:
 
       - name: Wait before retrying GitHub Pages deployment
         if: ${{ steps.deploy-pages.outcome == 'failure' }}
-        run: sleep 30
+        run: sleep 90
 
       - name: Retry deploy to GitHub Pages
+        id: deploy-pages-retry-1
         if: ${{ steps.deploy-pages.outcome == 'failure' }}
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+        with:
+          token: ${{ github.token }}
+
+      - name: Wait before final GitHub Pages deployment retry
+        if: ${{ steps.deploy-pages.outcome == 'failure' && steps.deploy-pages-retry-1.outcome == 'failure' }}
+        run: sleep 180
+
+      - name: Final retry deploy to GitHub Pages
+        if: ${{ steps.deploy-pages.outcome == 'failure' && steps.deploy-pages-retry-1.outcome == 'failure' }}
         uses: actions/deploy-pages@v5
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- explain and address recurring transient GitHub Pages failures
- increase the first retry delay from 30s to 90s
- add a final deploy retry after an additional 180s when Pages still returns a transient failure

## Validation
- parsed .github/workflows/deploy.yml locally
- npm run build in bolt-app
- inspected failing runs 28720879301 and 28722165277